### PR TITLE
Run type maker scripts

### DIFF
--- a/scripts/run_type_maker/add_run_type.sh
+++ b/scripts/run_type_maker/add_run_type.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+mysql -u $1 --password=$2 $3 -A -e"INSERT INTO run_type(file_definition_id, run_name, category_code) VALUES (${4}, '${5}', '${6}');"

--- a/scripts/run_type_maker/get_instrument_ids.sh
+++ b/scripts/run_type_maker/get_instrument_ids.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+mysql -u $1 --password=$2 $3 -A -e"SELECT u.firstname, u.surname, i.name, i.id, f.description, f.id FROM user u INNER JOIN instrument i ON i.owner = u.id INNER JOIN file_definition f ON f.instrument_id = i.id;"

--- a/scripts/run_type_maker/get_run_types.sh
+++ b/scripts/run_type_maker/get_run_types.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+mysql -u $1 --password=$2 $3 -A -e"SELECT * FROM run_type WHERE file_definition_id = ${4};"


### PR DESCRIPTION
QuinCe does not yet have support for adding new Run Types when they are detected after the instrument has been defined.

These scripts provide a relatively quick way to add new Run Types manually.