### PR TITLE
(#705) Fix plot screen on dataset switch

### DIFF
--- a/WebApp/src/uk/ac/exeter/QuinCe/web/PlotPageBean.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/web/PlotPageBean.java
@@ -441,6 +441,7 @@ public abstract class PlotPageBean extends BaseManagedBean {
 	 */
 	public String start() {
 		try {
+			tableRowIds = null;
 			dataset = DataSetDB.getDataSet(getDataSource(), datasetId);
 
 			variables = new VariableList();


### PR DESCRIPTION
Viewing the plot screen did not correctly clear data if a previous dataset had been viewed, preventing much of the interaction from working.