### PR TITLE
(#713) Map value displayed correctly

### DIFF
--- a/WebApp/WebContent/resources/script/plotPage.js
+++ b/WebApp/WebContent/resources/script/plotPage.js
@@ -1096,7 +1096,7 @@ function displayMapFeatureInfo(event, pixel) {
 		featureInfo += feature['data'][1];
 		featureInfo += ' ';
 		featureInfo += ' <b>Value:</b> '
-		featureInfo += feature['data'][6];
+		featureInfo += feature['data'][5];
 	}
 	
 	$('#map' + index + 'Value').html(featureInfo);


### PR DESCRIPTION
Hovering over a map point now displays the point's value instead of `undefined`.