### PR TITLE
Issue #740 (includes #739 ) Automatic update of test server

### DIFF
--- a/Documentation/Design/Database/Database_Migration.txt
+++ b/Documentation/Design/Database/Database_Migration.txt
@@ -1,0 +1,35 @@
+% QuinCe Database Migration system
+
+# Version History
+
+Version      Date                     Description
+---------    ----------------------   ------------------------------------------------------
+alpha2.02    2018-02-27               Database migration scripts
+
+
+# Database migration scripts
+
+Database migration scripts are handled by the flywayMigration library provided
+by boxfuse, https://flywaydb.org/
+
+Flyway functionality is enabled using the flyway plgin for gradle. Database
+migration scripts are added to the folder
+
+* src/migrations/flywayMigrations/dbmigrations
+
+where the migration scripts are sql files named after the following convention:
+
+* V[number]__[any_name].sql
+
+An example file could be eg: V2__github_issue_740.sql
+...referencing github issue #740 for the QuinCe project.
+
+Database schema versions is simply a running number starting on one for the
+database baseline, so start you script on the lowest available number. Migration
+scripts not applied will be run on the next migration.
+
+Migration scripts for the test server are applied daily after resetting the
+database to the state of the production database.
+
+For the production server, migration scripts that have not yet run, will be
+applied on the next release.

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,15 @@ buildscript {
    }
    dependencies {
        classpath 'org.akhikhl.gretty:gretty:2.0.0'
+
+       // Flyway migration needs the mysql connector
+       classpath 'mysql:mysql-connector-java:5.1.36'
    }
+}
+
+// Flyway database migration plugin:
+plugins {
+    id "org.flywaydb.flyway" version "5.0.7"
 }
 
 apply plugin: 'java'
@@ -81,7 +89,7 @@ sourceSets {
             srcDirs = ['WebApp/src', 'src/QC_Routines/src']
         }
         resources {
-            srcDirs = ['WebApp/WebContent/resources']
+            srcDirs = ['WebApp/WebContent/resources', 'src/migrations']
         }
 
     }
@@ -105,4 +113,19 @@ eclipse {
         }
     }
 
+}
+def rootPath = file('.').absolutePath
+def webContext=new XmlSlurper().parse(rootPath + '/WebApp/WebContent/META-INF/context.xml')
+
+// Load db setup
+// Database migration scripts are added to the folder
+// src/migrations/flywayMigrations/dbmigrations
+// sql migration files are named with:
+// V[number]__[any_name].sql, eg V2__new_table_record.sql
+flyway {
+  url = webContext.Resource.@url
+  user = webContext.Resource.@username
+  password = webContext.Resource.@password
+  locations = ["classpath:db_migrations"]
+  baselineOnMigrate = true
 }

--- a/quince.setup.default
+++ b/quince.setup.default
@@ -14,3 +14,5 @@
 %db_port%=3306
 %db_host%=localhost
 %app.urlstub%=http://localhost:8080/QuinCe
+%git_test_branch%=master
+%slack_app_url%=https://hooks.slack.com/services/XXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXX

--- a/scripts/full_restore_from_prod.sh
+++ b/scripts/full_restore_from_prod.sh
@@ -10,13 +10,16 @@
 # - Alert to slack on errors
 # - Start apache with new codebase
 #
+# This script will be run in cron on the test server with
+# the following command:
+# 5 5 * * * . cd ~/QuinCe && scripts/full_restore_from_prod.sh >~/cron.out 2>&1
 ############################################################
 
 # Restore database
 ssh_user=${@:$OPTIND:1}
 
 scripts/db_restore_from_prod.sh $ssh_user || \
-  exit 1;
+  exit 1; # Failed to restore database from production database.
 
 branch=$(scripts/get_setup_property.sh git_test_branch)
 
@@ -45,6 +48,9 @@ tmpfile=/tmp/gradle_build_test_output.txt
 # Clean, test and build the war file. Failing tests are sent to the QuinCe-QC
 # slack #errors channel
 ./gradlew clean test war > $tmpfile 2>&1 || scripts/slackerror.sh -f $tmpfile
+
+#  Run upgrade scripts to get the system up to date with the current version
+scripts/upgrade.sh > $tmpfile 2>&1 || scripts/slackerror.sh -f $tmpfile
 
 # Start tomcat with nohup to allow cron to exit while tomcat keeps running
 nohup ./gradlew appStartWar &

--- a/scripts/full_restore_from_prod.sh
+++ b/scripts/full_restore_from_prod.sh
@@ -34,6 +34,17 @@ git submodule update --init
 scripts/setup_replace_strings.sh
 scripts/setup_hide_changes.sh
 
+####################
 # gradle tasks
+###################
+
+# Stop tomcat
+./gradlew appStop
 tmpfile=/tmp/gradle_build_test_output.txt
+
+# Clean, test and build the war file. Failing tests are sent to the QuinCe-QC
+# slack #errors channel
 ./gradlew clean test war > $tmpfile 2>&1 || scripts/slackerror.sh -f $tmpfile
+
+# Start tomcat with nohup to allow cron to exit while tomcat keeps running
+nohup ./gradlew appStartWar &

--- a/scripts/full_restore_from_prod.sh
+++ b/scripts/full_restore_from_prod.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+############################################################
+#
+# This script restores the full production environment
+# to the test server:
+# - Run db_restore_from_prod.sh
+# - git fetch && git checkout master
+# - gradle clean build test
+# - Alert to slack on errors
+# - Start apache with new codebase
+#
+############################################################
+
+# Restore database
+ssh_user=${@:$OPTIND:1}
+
+scripts/db_restore_from_prod.sh $ssh_user || \
+  { echo "Error updating database. Exit!"; exit 1 }
+
+branch=$(scripts/get_setup_property.sh git_test_branch)
+
+# reset setup
+scripts/setup_reverse_strings.sh
+scripts/setup_show_changes.sh
+
+# Checkout latest updates
+git fetch
+git checkout $branch
+git reset --hard
+git submodule update --init
+
+# setup
+scripts/setup_replace_strings.sh
+scripts/setup_hide_changes.sh
+
+# gradle tasks
+tmpfile=/tmp/gradle_build_test_output.txt
+./gradlew clean test war > $tmpfile 2>&1 || scripts/slackerror.sh -f $tmpfile

--- a/scripts/full_restore_from_prod.sh
+++ b/scripts/full_restore_from_prod.sh
@@ -16,7 +16,7 @@
 ssh_user=${@:$OPTIND:1}
 
 scripts/db_restore_from_prod.sh $ssh_user || \
-  { echo "Error updating database. Exit!"; exit 1 }
+  exit 1;
 
 branch=$(scripts/get_setup_property.sh git_test_branch)
 

--- a/scripts/get_setup_property.sh
+++ b/scripts/get_setup_property.sh
@@ -34,6 +34,12 @@ then
 elif [ $1 = 'filestore' ]
 then
   propertyvalue=$(sed -n 's/^filestore *= *\(.*\)$/\1/p' configuration/quince.properties)
+else
+  propertyvalue=$(sed -n "s/^%$1% *= *\(.*\) *$/\1/p" quince.setup)
+  if [ -z $propertyvalue ]
+  then
+    propertyvalue=$(sed -n "s/^%$1% *= *\(.*\) *$/\1/p" quince.setup.default)
+  fi
 fi
 
 echo $propertyvalue

--- a/scripts/slackerror.sh
+++ b/scripts/slackerror.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+############################################################
+#
+# This script restores the full production environment
+# to the test server:
+# - Run db_restore_from_prod.sh
+# - git fetch && git checkout master
+# - gradle clean build test
+# - Alert to slack on errors
+# - Start apache with new codebase
+#
+############################################################
+OPTIND=1
+input_file=""
+
+while getopts "v:f:" opt; do
+  case "$opt" in
+  f)  input_file=$OPTARG
+    ;;
+  esac
+done
+
+# Escape
+json_escape () {
+  # Use php json_encode to escape text for json output
+  printf '%s' "$1" | php -r 'echo json_encode(file_get_contents("php://stdin"));'
+}
+
+
+url=$(./scripts/get_setup_property.sh slack_app_url)
+
+# Either data from input
+message=$(json_escape "$1")
+
+# or read from file
+if [ -n $input_file ]
+then
+  message="$(cat $input_file)"
+  message=$(json_escape "$message")
+fi
+
+json="{\"text\":$message}"
+
+curl -s -X POST -H 'Content-type: application/json' --data "$json" $url

--- a/scripts/testserver/centos_setup.txt
+++ b/scripts/testserver/centos_setup.txt
@@ -17,6 +17,8 @@ systemctl start mariadb
 yum install java-1.8.0-openjdk.x86_64 -y
 yum install java-1.8.0-openjdk-devel.x86_64 -y
 yum install git -y
+yum install mailx -y
+yum install php-cli -y
 
 
 # Setup folders for inncoming data from prod server:
@@ -79,4 +81,3 @@ database=scripts/get_setup_property.sh database
 
 echo "create database if not exists $database character set utf8" |mysql -uroot
 echo "grant all privileges on $database.* to $username@'localhost' identified by '$password'" |mysql -uroot
-

--- a/scripts/testserver/cron.txt
+++ b/scripts/testserver/cron.txt
@@ -1,0 +1,6 @@
+################################################################
+# Cron scripts for the test server.                            #
+# Scripts should be installed using crontab -e by user centos  #
+################################################################
+
+5 5 * * * . cd ~/QuinCe && scripts/full_restore_from_prod.sh >~/cron.out 2>&1

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+##############################################
+# This script simply runs the flyway upgrade
+# gradle plugin. Might be extended to run
+# more migration-tasks later.
+##############################################
+
+./gradlew flywayMigrate

--- a/src/migrations/db_migrations/README.md
+++ b/src/migrations/db_migrations/README.md
@@ -1,0 +1,12 @@
+-- Database migration folder --
+Database migration scripts should be added to this folder:
+
+* src/migrations/db_migrations
+
+Migration files are simply sql files, named using the following convention:
+
+```
+V[number]__[any_name].sql, eg V2V2__github_issue_740.sql
+```
+
+...referencing github issue #740.


### PR DESCRIPTION
These issues include functionality to make automatic updates on the test server, and executing database migrations. The issues are just shell-scripts, and will not interfere with the actual website. I think these should be included in the alpha2.02 release, as it will allow the test server to function correctly.