### PR TITLE
(#662) Make sure page titles are consistent

### DIFF
--- a/WebApp/WebContent/WEB-INF/templates/basic_page.xhtml
+++ b/WebApp/WebContent/WEB-INF/templates/basic_page.xhtml
@@ -4,12 +4,14 @@
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
   <h:head>
-    <title><ui:insert name="title">Welcome</ui:insert> - QuinCe</title>
+    <title><ui:insert name="title">Welcome</ui:insert> - #{utils.siteName}</title>
     <ui:insert name="localHead"/>
   </h:head>
   <h:body>
-      <h:outputStylesheet name="style/main.css"/>
-      <div class="pageTitle"><ui:insert name="pageTitle">Page Title</ui:insert></div>
+    <h:outputStylesheet name="style/main.css"/>
+    <div class="pageTitle">
+      <ui:insert name="pageTitle">#{utils.siteName}</ui:insert>
+    </div>
     <ui:insert name="content">No content supplied to template!</ui:insert>
   </h:body>
 </html>

--- a/WebApp/WebContent/WEB-INF/templates/menu_page.xhtml
+++ b/WebApp/WebContent/WEB-INF/templates/menu_page.xhtml
@@ -7,7 +7,7 @@
       xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
 
   <h:head>
-    <title><ui:insert name="title">Welcome</ui:insert> - QuinCe</title>
+    <title><ui:insert name="title">Welcome</ui:insert> - #{utils.siteName}</title>
     <h:outputScript library="primefaces" name="jquery/jquery.js"/>
     <ui:insert name="localHead"></ui:insert>
   </h:head>

--- a/WebApp/WebContent/WEB-INF/templates/plot_page.xhtml
+++ b/WebApp/WebContent/WEB-INF/templates/plot_page.xhtml
@@ -7,7 +7,7 @@
       xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
 
     <h:head>
-    <title><ui:insert name="title">Welcome</ui:insert> - QuinCe</title>
+    <title><ui:insert name="title">Welcome</ui:insert> - #{utils.siteName}</title>
     <h:outputScript library="primefaces" name="jquery/jquery.js"/>
     <ui:insert name="localHead"></ui:insert>
     <h:outputScript name="script/jquery.splitter.js"/>

--- a/WebApp/WebContent/instrument/new/instrument_name.xhtml
+++ b/WebApp/WebContent/instrument/new/instrument_name.xhtml
@@ -5,7 +5,7 @@
   xmlns:p="http://primefaces.org/ui"
   xmlns:c="http://java.sun.com/jsp/jstl/core"
   template="/WEB-INF/templates/new_instrument.xhtml">
-
+  <ui:param name="pageTitle" value="New Instrument - #{utils.siteName}" />
   <ui:define name="title">New Instrument</ui:define>
   <ui:define name="instrumentHead">
     <script>

--- a/WebApp/WebContent/user/account.xhtml
+++ b/WebApp/WebContent/user/account.xhtml
@@ -6,7 +6,8 @@
   xmlns:c="http://java.sun.com/jsp/jstl/core"
   template="/WEB-INF/templates/menu_page.xhtml">
 
-  <ui:define name="title">Account</ui:define>
+  <ui:define name="title">Account details</ui:define>
+  <ui:define name="pageTitle">Account details - #{utils.siteName}</ui:define>
   <ui:define name="localHead">
     <c:set var="mainMenuActiveIndex" value="3" scope="request"/>
   </ui:define>

--- a/WebApp/WebContent/user/code_sent.xhtml
+++ b/WebApp/WebContent/user/code_sent.xhtml
@@ -4,6 +4,7 @@
   template="/WEB-INF/templates/basic_page.xhtml">
 
   <ui:define name="title">Code Sent</ui:define>
+  <ui:define name="pageTitle">Code Sent - #{utils.siteName}</ui:define>
 
   <ui:define name="content">
     <div id="contentbox">

--- a/WebApp/WebContent/user/user_edit.xhtml
+++ b/WebApp/WebContent/user/user_edit.xhtml
@@ -4,7 +4,9 @@
   xmlns:p="http://primefaces.org/ui"
   xmlns:f="http://xmlns.jcp.org/jsf/core"
   template="/WEB-INF/templates/app_page.xhtml">
-  <ui:define name="title">Calibration Details</ui:define>
+
+  <ui:define name="title">Edit User</ui:define>
+  <ui:define name="pageTitle">Edit User - #{utils.siteName}</ui:define>
 
   <ui:define name="content">
     <h1>My Account</h1>

--- a/WebApp/WebContent/user/verify_email.xhtml
+++ b/WebApp/WebContent/user/verify_email.xhtml
@@ -9,6 +9,7 @@
   </f:metadata>
 
   <ui:define name="title">Email Verification</ui:define>
+  <ui:define name="pageTitle">Email Verification - #{utils.siteName}</ui:define>
 
   <ui:define name="content">
     <div id="contentbox">

--- a/WebApp/src/uk/ac/exeter/QuinCe/web/ServletUtilsBean.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/web/ServletUtilsBean.java
@@ -22,7 +22,10 @@ import uk.ac.exeter.QuinCe.web.system.ServletUtils;
 @SessionScoped
 public class ServletUtilsBean{
 
-
+  /**
+   * Application site name
+   */
+  private final String siteName = "QuinCe";
 
   /**
    * Use this to get the GlobalSessionData object for this session.
@@ -52,5 +55,15 @@ public class ServletUtilsBean{
       }
     }
     return null;
+  }
+
+  /**
+   * The site name for the QuinCe application can be used throughout the
+   * application for labels and headers
+   *
+   * @return
+   */
+  public String getSiteName() {
+    return siteName;
   }
 }


### PR DESCRIPTION
Replace Page Title with the site name in the template. Also fetch site-name from a property in the utils - bean.

Fixes #662 