### PR TITLE
(#438) Remove bindEvents(), making spinner jump 2 steps.

### DIFF
--- a/WebApp/WebContent/resources/script/newInstrument.js
+++ b/WebApp/WebContent/resources/script/newInstrument.js
@@ -130,16 +130,15 @@ function getHeaderMode() {
 }
 
 function disableSpinner(spinnerObject) {
-    spinnerObject.input.prop("disabled", true);
-    spinnerObject.jq.addClass("ui-state-disabled");
-    spinnerObject.upButton.unbind('mousedown.spinner')
-    spinnerObject.downButton.unbind('mousedown.spinner')
+  spinnerObject.input.prop("disabled", true);
+  spinnerObject.jq.addClass("ui-state-disabled");
+  $('#newInstrumentForm\\:headerLineCount').css('pointer-events','none');
 }
 
 function enableSpinner(spinnerObject) {
-   spinnerObject.input.prop("disabled", false);
-   spinnerObject.jq.removeClass("ui-state-disabled");
-   spinnerObject.bindEvents()
+  spinnerObject.input.prop("disabled", false);
+  spinnerObject.jq.removeClass("ui-state-disabled");
+  $('#newInstrumentForm\\:headerLineCount').css('pointer-events','all');
 }
 
 function numberOnly(event) {


### PR DESCRIPTION
- Add css-approach for disabling spinner buttons

Fixes #438 