### PR TITLE
(#797) Reinstate job list methods

### DIFF
--- a/WebApp/src/uk/ac/exeter/QuinCe/web/jobs/JobsBean.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/web/jobs/JobsBean.java
@@ -100,6 +100,13 @@ public class JobsBean extends BaseManagedBean {
       e.printStackTrace();
       jobCounts = null;
     }
+
+    try {
+      jobList = JobManager.getJobList(ServletUtils.getDBDataSource());
+    } catch (Exception e) {
+      e.printStackTrace();
+      jobList = null;
+    }
   }
 
   /**


### PR DESCRIPTION
The methods required for the job list table were deprecated and removed while sorting out the use of Date objects, but they weren't replaced with anything. For now the methods have been restored, but remain Deprecated. Maybe they can stay as they are, or maybe they need to be altered - we need to discuss it.