### PR TITLE
#809 and #810: database maintenance scripts as gradle tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -165,3 +165,43 @@ spotless {
     endWithNewline()
   }
 }
+
+// Delete a data set from the database
+task delete_dataset(type: Exec) {
+  java.util.regex.Pattern dbNamePattern = ~/([^\/?]*)\?/
+  java.util.regex.Matcher matcher = dbNamePattern.matcher(webContext.Resource.@url.toString())
+  if (!matcher.find()) {
+    throw new Exception("Cannot extract database name from URL")
+  }
+  
+  String dbName = webContext.Resource.@url.toString().substring(matcher.start(1), matcher.end(1))
+  String user = webContext.Resource.@username
+  String password = webContext.Resource.@password
+
+  String datasetId = ""
+  if (project.hasProperty("datasetId")) {
+    datasetId = project.getProperty("datasetId")
+  }
+
+  commandLine("./scripts/database_maintenance/delete_dataset.sh", dbName, user, password, datasetId)
+}
+
+// Delete a data set from the database
+task delete_instrument(type: Exec) {
+  java.util.regex.Pattern dbNamePattern = ~/([^\/?]*)\?/
+  java.util.regex.Matcher matcher = dbNamePattern.matcher(webContext.Resource.@url.toString())
+  if (!matcher.find()) {
+    throw new Exception("Cannot extract database name from URL")
+  }
+  
+  String dbName = webContext.Resource.@url.toString().substring(matcher.start(1), matcher.end(1))
+  String user = webContext.Resource.@username
+  String password = webContext.Resource.@password
+
+  String instrumentId = ""
+  if (project.hasProperty("instrumentId")) {
+    instrumentId = project.getProperty("instrumentId")
+  }
+
+  commandLine("./scripts/database_maintenance/delete_instrument.sh", dbName, user, password, instrumentId)
+}

--- a/scripts/database_maintenance/delete_dataset.sh
+++ b/scripts/database_maintenance/delete_dataset.sh
@@ -1,23 +1,27 @@
 #!/bin/bash
 
-read -p "Database Name (quince_dev): " db_name
-if [ -z "$db_name" ]
-  then db_name="quince_dev"
+# This script deletes a data set and all related records from the database
+# It is designed to be run from a gradle task
+#
+# The script takes the database url, username and password as parameters
+# It will prompt the user for the ID of the data set to be deleted
+
+# Usage:
+# delete_dataset.sh db_name db_user db_password dataset_id
+
+db_name=$1
+db_user=$2
+db_password=$3
+dataset_id=$4
+
+if [ -z $dataset_id ]
+then
+  echo "Missing database ID"
+  echo "Run gradle task as: gradle delete_dataset -PdatasetId=<id>"
+  exit 1
 fi
 
-
-read -p "Database User (quince_dev): " db_user
-if [ -z "$db_user" ]
-  then db_user="quince_dev"
-fi
-
-while [ -z "$dataset_id" ]
-do
-  read -p "Dataset ID: " dataset_id
-done
-
-
-mysql -u $db_user -p $db_name <<EOF
+mysql --user=$db_user --password=$db_password $db_name <<EOF
   DELETE FROM equilibrator_pco2 WHERE measurement_id IN (SELECT id FROM dataset_data WHERE dataset_id = $dataset_id);
   DELETE FROM dataset_data WHERE dataset_id = $dataset_id;
   DELETE FROM calibration_data WHERE dataset_id = $dataset_id;

--- a/scripts/database_maintenance/delete_instrument.sh
+++ b/scripts/database_maintenance/delete_instrument.sh
@@ -17,7 +17,7 @@ instrument_id=$4
 if [ -z $instrument_id ]
 then
   echo "Missing instrument ID"
-  echo "Run gradle task as: gradle delete_dataset -PinstrumentId=<id>"
+  echo "Run gradle task as: gradle delete_instrument -PinstrumentId=<id>"
   exit 1
 fi
 

--- a/scripts/database_maintenance/delete_instrument.sh
+++ b/scripts/database_maintenance/delete_instrument.sh
@@ -1,23 +1,27 @@
 #!/bin/bash
 
-read -p "Database Name (quince_dev): " db_name
-if [ -z "$db_name" ]
-  then db_name="quince_dev"
+# This script deletes a data set and all related records from the database
+# It is designed to be run from a gradle task
+#
+# The script takes the database url, username and password as parameters
+# It will prompt the user for the ID of the data set to be deleted
+
+# Usage:
+# delete_dataset.sh db_name db_user db_password dataset_id
+
+db_name=$1
+db_user=$2
+db_password=$3
+instrument_id=$4
+
+if [ -z $instrument_id ]
+then
+  echo "Missing instrument ID"
+  echo "Run gradle task as: gradle delete_dataset -PinstrumentId=<id>"
+  exit 1
 fi
 
-
-read -p "Database User (quince_dev): " db_user
-if [ -z "$db_user" ]
-  then db_user="quince_dev"
-fi
-
-while [ -z "$instrument_id" ]
-do
-  read -p "Instrument ID: " instrument_id
-done
-
-
-mysql -u $db_user -p $db_name <<EOF
+mysql --user=$db_user --password=$db_password $db_name <<EOF
   DELETE FROM equilibrator_pco2 WHERE measurement_id IN (SELECT id FROM dataset_data WHERE dataset_id IN (SELECT id FROM dataset WHERE instrument_id = $instrument_id));
   DELETE FROM dataset_data WHERE dataset_id IN (SELECT id FROM dataset WHERE instrument_id = $instrument_id);
   DELETE FROM calibration_data WHERE dataset_id IN (SELECT id FROM dataset WHERE instrument_id = $instrument_id);

--- a/scripts/database_maintenance/delete_instrument.sh
+++ b/scripts/database_maintenance/delete_instrument.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+read -p "Database Name (quince_dev): " db_name
+if [ -z "$db_name" ]
+  then db_name="quince_dev"
+fi
+
+
+read -p "Database User (quince_dev): " db_user
+if [ -z "$db_user" ]
+  then db_user="quince_dev"
+fi
+
+while [ -z "$instrument_id" ]
+do
+  read -p "Instrument ID: " instrument_id
+done
+
+
+mysql -u $db_user -p $db_name <<EOF
+  DELETE FROM equilibrator_pco2 WHERE measurement_id IN (SELECT id FROM dataset_data WHERE dataset_id IN (SELECT id FROM dataset WHERE instrument_id = $instrument_id));
+  DELETE FROM dataset_data WHERE dataset_id IN (SELECT id FROM dataset WHERE instrument_id = $instrument_id);
+  DELETE FROM calibration_data WHERE dataset_id IN (SELECT id FROM dataset WHERE instrument_id = $instrument_id);
+  DELETE FROM dataset WHERE instrument_id = $instrument_id;
+
+  DELETE FROM calibration WHERE instrument_id = $instrument_id;
+
+  DELETE FROM data_file WHERE file_definition_id IN (SELECT id FROM file_definition WHERE instrument_id = $instrument_id);
+  DELETE FROM run_type WHERE file_definition_id IN (SELECT id FROM file_definition WHERE instrument_id = $instrument_id);
+  DELETE FROM file_column WHERE file_definition_id IN (SELECT id FROM file_definition WHERE instrument_id = $instrument_id);
+  DELETE FROM file_definition WHERE instrument_id = $instrument_id;
+
+  DELETE FROM instrument WHERE id = $instrument_id;
+EOF
+
+echo "NOTE: Files HAVE NOT been removed from the file store."


### PR DESCRIPTION
They work, but there's a couple of things I'd like to discuss.

* Is this the best approach for doing this?
* There's a lot of duplicated code in the two gradle tasks. Can we somehow get rid of it? A couple of possibilities:
  - We could make a method to get the `db_name`
  - We could have a single `database_maintenance` task and pass in the name of the script to run and the id on the command line. Which would also mean we can add more scripts without more gradle entries. Just need to think about how the command line options would be handled.