### PR TITLE
(#808) Clean and build project before trying to migrate

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,6 +128,13 @@ flyway {
   baselineOnMigrate = true
 }
 
+// Make sure project is cleaned and build before running flywayMigrate task
+flywayMigrate {
+  dependsOn 'clean'
+  dependsOn 'war'
+  tasks.findByName('war').mustRunAfter 'clean'
+}
+
 spotless {
   // Blocks defining how to format different code types
   format 'java', {

--- a/src/migrations/db_migrations/README.md
+++ b/src/migrations/db_migrations/README.md
@@ -6,7 +6,17 @@ Database migration scripts should be added to this folder:
 Migration files are simply sql files, named using the following convention:
 
 ```
-V[number]__[any_name].sql, eg V2V2__github_issue_740.sql
+V[number]__[any_name].sql, eg V2__github_issue_740.sql
 ```
-
 ...referencing github issue #740.
+
+Look in the folder `src/migrations/db_migrations` to see which version is
+current, and increase the number by one for your new migration. The first file
+added should be named V2__[something].sql, as the first migration is the
+baseline and has no migration file.
+
+To run a migration, use the upgrade-script:
+
+```
+$ ./scripts/upgrade.sh
+```


### PR DESCRIPTION
To locate the sql migration files on the project classpath, gradle clean and build needs to run first.