### PR TITLE
(#813) Foreign key restraint for dataset_id on calibration data

### DIFF
--- a/src/migrations/db_migrations/V3__restrict_delete_dataset_when_calibration_exists_issue_813.sql
+++ b/src/migrations/db_migrations/V3__restrict_delete_dataset_when_calibration_exists_issue_813.sql
@@ -1,0 +1,1 @@
+ALTER TABLE calibration_data ADD CONSTRAINT fk_dataset_id FOREIGN KEY (dataset_id) REFERENCES dataset(id) ON UPDATE RESTRICT ON DELETE RESTRICT;


### PR DESCRIPTION
Preventing dataset to be deleted before associated calibration data is deleted. 

Close #813 