### PR TITLE
(#801) Overriding the animation effect on dropdowns

### DIFF
--- a/WebApp/WebContent/WEB-INF/faces-config.xml
+++ b/WebApp/WebContent/WEB-INF/faces-config.xml
@@ -213,4 +213,8 @@
       <to-view-id>/dataset/export.xhtml</to-view-id>
     </navigation-case>
   </navigation-rule>
+  <component>
+    <component-type>org.primefaces.component.SelectOneMenu</component-type>
+    <component-class>uk.ac.exeter.QuinCe.web.ui.FastSelectOneMenu</component-class>
+  </component>
 </faces-config>

--- a/WebApp/src/uk/ac/exeter/QuinCe/web/ui/FastSelectOneMenu.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/web/ui/FastSelectOneMenu.java
@@ -1,0 +1,14 @@
+package uk.ac.exeter.QuinCe.web.ui;
+
+import org.primefaces.component.selectonemenu.SelectOneMenu;
+
+public class FastSelectOneMenu extends SelectOneMenu {
+  @Override
+  public String getEffectSpeed() {
+    String effectSpeed = super.getEffectSpeed();
+    if (effectSpeed == null) {
+      effectSpeed = "fast";
+    }
+    return effectSpeed;
+  }
+}


### PR DESCRIPTION
Not sure if this was exactly what you where looking for, but I could not find out if there is a way to adjust the animation speed in primefaces. Overriding the animation on opacity makes the dropdown appear more or less immediately (but needs the vilified !important - statement ...)

Close #801 