### PR TITLE
(#859) Disable DEFINER - statement

### DIFF
--- a/scripts/db_restore_from_prod.sh
+++ b/scripts/db_restore_from_prod.sh
@@ -81,7 +81,7 @@ fi
 # Restore database
 echo "drop database $database"|mysql -u$username -p$password
 echo "create database $database character set utf8" |mysql -u$username -p$password
-zcat < $file | \
+zcat < $file | sed 's/\/\*\!\([0-9]\+\) DEFINER=/\/* \1 DEFINER=/g' | \
   mysql -u$username -p$password $database --default-character-set utf8
 
 # Delete tempfile, don't display errors


### PR DESCRIPTION
- Done by removing ! from '/*!99999 DEFINER=' in sql-dump

For some reason the error only shows on the actual test server. To test it there, check out jonasfh/github/859 and run `./scripts/db_restore_from_prod.sh`

Close #859 

