### PR TITLE
(#817) Aliased run types support

### DIFF
--- a/WebApp/WebContent/data_file/upload.xhtml
+++ b/WebApp/WebContent/data_file/upload.xhtml
@@ -18,148 +18,162 @@
   <ui:define name="content">
     <h:form id="uploadForm" method="post" charset="utf8">
       <div class="pageTable">
-        <div id="uploadFile">
+         <div id="uploadFile">
           <p:messages id="messages" autoUpdate="true" closable="true"/>
           <div id="messages" class="error listBox hidden"></div>
           <p:outputLabel value="Select a file to upload"/>
-          <p:fileUpload fileUploadListener="#{fileUpload.handleFileUpload}"
-          mode="advanced" auto="false" oncomplete="extractNext()"
-          multiple="true" update="fileDetails" widgetVar="fileUploadWidget"/>
-        </div>
-        <p:outputPanel id="fileDetails" styleClass="#{fileUpload.displayClass}">
-          <p:remoteCommand
-          name="extractNext"
-          action="#{fileUpload.extractNext()}"
-          process="@this"
-          update="fileList storeFileButton" />
-
-
-          <p:dialog id="msgDialog" widgetVar="msgDialog" header="Errors and messages" minHeight="40" >
-            <p:scrollPanel style="height:200px" mode="native">
-              <div id="messageText"></div>
-            </p:scrollPanel>
-          </p:dialog>
-          <p:dataTable
-          id="fileList"
-          var="uploadedFile"
-          value="#{fileUpload.uploadedFiles}"
-          rowStyleClass="#{uploadedFile.messageClass}"
-          rowIndexVar="rowIndex"
-          >
+          <p:fileUpload
+            fileUploadListener="#{fileUpload.handleFileUpload}"
+            mode="advanced" auto="false" oncomplete="extractNext()"
+            multiple="true" update="fileDetails" widgetVar="fileUploadWidget"
+          />
+          <p:outputPanel id="fileDetails" styleClass="#{fileUpload.displayClass}">
+            <p:remoteCommand
+            name="extractNext"
+            action="#{fileUpload.extractNext()}"
+            process="@this"
+            update="fileList storeFileButton" />
+            <p:dialog id="msgDialog" widgetVar="msgDialog" header="Errors and messages" minHeight="40" >
+              <p:scrollPanel style="height:200px" mode="native">
+                <div id="messageText"></div>
+              </p:scrollPanel>
+            </p:dialog>
+            <p:dataTable
+              id="fileList"
+              var="uploadedFile"
+              value="#{fileUpload.uploadedFiles}"
+              rowStyleClass="#{uploadedFile.hasMessages ? 'error' : ''}"
+              rowIndexVar="rowIndex"
+            >
               <p:column headerText="Filename">
-                  <h:outputText value="#{uploadedFile.name}" />
+                <h:outputText value="#{uploadedFile.name}" />
               </p:column>
               <p:column headerText="Start date">
-                  <h:outputText escape="false"
-              value="#{uploadedFile.startDate}" >
+                <ui:fragment rendered="#{!uploadedFile.processed}">
+                  <div class="tablespinner loading"/>
+                </ui:fragment>
+                <h:outputText escape="false" value="#{uploadedFile.startDate}" rendered="#{uploadedFile.processed}">
                   <f:convertDateTime pattern="#{fileUpload.longDateFormat}" />
-              </h:outputText>
-              <div class="tablespinner #{uploadedFile.startDate == null and uploadedFile.messageClass == '' ? 'loading' : ''}"></div>
+                </h:outputText>
               </p:column>
-
               <p:column headerText="End date">
-                  <h:outputText escape="false"
-              value="#{uploadedFile.endDate}" >
+                <ui:fragment rendered="#{!uploadedFile.processed}">
+                  <div class="tablespinner loading"/>
+                </ui:fragment>
+                <h:outputText escape="false" value="#{uploadedFile.endDate}" rendered="#{uploadedFile.processed}">
                   <f:convertDateTime pattern="#{fileUpload.longDateFormat}" />
-              </h:outputText>
-              <div class="tablespinner #{uploadedFile.endDate == null and uploadedFile.messageClass == '' ? 'loading' : ''}"></div>
+                </h:outputText>
               </p:column>
-
               <p:column headerText="No. of records">
-                  <h:outputText value="#{uploadedFile.dataFile.recordCount}" />
+                <ui:fragment rendered="#{!uploadedFile.processed}">
+                  <div class="tablespinner loading"/>
+                </ui:fragment>
+                <h:outputText value="#{uploadedFile.dataFile.recordCount}" rendered="#{uploadedFile.processed}"/>
               </p:column>
               <p:column headerText="Store file to database">
-              <p:selectBooleanCheckbox
-              id="fileStoreCheckbox"
-              styleClass="#{uploadedFile.endDate == null or uploadedFile.messageClass != '' ? 'hidden' : 'ready'}"
-              value="#{uploadedFile.store}" />
-              <p:commandButton
-              icon="ui-icon-notice"
-              styleClass="messageButton #{uploadedFile.messageClass == '' ? 'hidden' : ''}"
-              onclick="renderMessages($(this).data('messages'))"
-              title="Errors"
-              value="Errors"
-              >
-                <f:passThroughAttribute name="data-messages" value="#{uploadedFile.messages}" />
-              </p:commandButton>
-              <p:commandButton
-              icon="ui-icon-plus"
-              styleClass="missingRunTypeButton #{uploadedFile.missingRunTypeClass}"
-              onclick="PF('runTypesDialog_#{rowIndex}').show()"
-              title="Unrecognised Run Types Found"
-              value="Unrecognised Run Types Found"
-              >
-              </p:commandButton>
-                <p:dialog widgetVar="runTypesDialog_#{rowIndex}"
-                modal="true">
-                <div class="runTypeFile">
-                  <p:fieldset legend="Unrecognised Run Types">
-                    <div class="instructions">
-                      This file contained unrecognised Run Types.
-                      Please assign them using the menu options.
-                    </div>
-                    <div class="ui-g">
-                      <ui:repeat
-                      value="#{uploadedFile.dataFile.missingRunTypes}"
-                      var="runType"
-                      rowKeyVar="index">
-                        <div class="ui-g-6">
-                          <label for="selectOneMenu_#{rowIndex}_#{index}">#{runType}</label>
-                        </div>
-                        <div class="ui-g-6">
-                          <p:selectOneMenu
-                          id="selectOneMenu_#{rowIndex}_#{index}"
-                          value="#{runType.runTypeCategoryCode}"
-                          >
-                            <f:selectItem itemLabel="Select Category" itemValue="" />
-                            <f:selectItems
-                            value="#{utils.runTypeCategories}"
-                            var="category"
-                            itemValue="#{category.code}"
-                            itemLabel="#{category.name}" />
-                          </p:selectOneMenu>
-                        </div>
-                      </ui:repeat>
-                    </div>
-                    <p:commandButton
-                    icon="ui-icon-check"
-                    actionListener="#{fileUpload.runTypesUpdated}"
-                    title="Save Run Types"
-                    value="Save Run Types"
-                    onclick="PF('runTypesDialog_#{rowIndex}').hide()"
-                    update="fileList"
-                    oncomplete="reProcessUploadedFiles()"
-                    >
-                      <f:param name="fileIndex" value="#{rowIndex}" />
-                    </p:commandButton>
-                  </p:fieldset>
-                  <p:fieldset legend="These run types are already defined">
-                    <div class="ui-g">
-                      <ui:repeat
-                      value="#{uploadedFile.dataFile.fileDefinition.runTypes.entrySet().toArray()}"
-                      var="runType"
-                      rowKeyVar="index"
-                      >
-                        <div class="ui-g-6"><h:outputText value="#{runType.key}" /></div>
-                        <div class="ui-g-6"><h:outputText value="#{runType.value.name}" /></div>
-                      </ui:repeat>
-                    </div>
-                  </p:fieldset>
-                </div>
-              </p:dialog>
-            </p:column>
-          </p:dataTable>
-        </p:outputPanel>
+                <ui:fragment rendered="#{!uploadedFile.processed}">
+                  <div class="tablespinner loading"/>
+                </ui:fragment>
+                <p:selectBooleanCheckbox
+                  id="fileStoreCheckbox"
+                  rendered="#{uploadedFile.processed and !uploadedFile.hasMessages}"
+                  value="#{uploadedFile.store}" />
+                <p:commandButton
+                  rendered="#{uploadedFile.processed and uploadedFile.hasMessages}"
+                  icon="ui-icon-notice"
+                  onclick="renderMessages($(this).data('messages'))"
+                  title="Errors"
+                  value="Errors"
+                >
+                  <f:passThroughAttribute name="data-messages" value="#{uploadedFile.messages}" />
+                </p:commandButton>
+                <ui:fragment rendered="#{uploadedFile.processed and uploadedFile.hasUnrecognisedRunTypes}">
+                  <p:commandButton
+                    icon="ui-icon-plus"
+                    onclick="PF('runTypesDialog_#{rowIndex}').show()"
+                    title="Unrecognised Run Types Found"
+                    value="Unrecognised Run Types Found"
+                  />
+                  <p:dialog widgetVar="runTypesDialog_#{rowIndex}" modal="true">
+                    <p:fieldset legend="Unrecognised Run Types">
+                      <div class="instructions">
+                        This file contained unrecognised Run Types.
+                        Please assign them using the menu options.
+                      </div>
+                      <table class="shrink noborder">
+                        <ui:repeat
+                          var="runType"
+                          value="#{uploadedFile.dataFile.missingRunTypes}"
+                          varStatus="missingRunTypeStatus"
+                        >
+                          <tr>
+                          <td class="labelsNoPad">
+                              <h:outputText value="#{runType.runType}"/>
+                            </td>
+                            <td>
+                              <p:selectOneMenu
+                                widgetVar="missingRunType_#{rowIndex}_#{missingRunTypeStatus.index}"
+                                value="#{runType.categoryCode}"
+                                onchange="runTypeChanged(#{rowIndex}, #{missingRunTypeStatus.index})"
+                              >
+                                <f:selectItems value="#{fileUpload.runTypeCategories}" var="category" itemValue="#{category.code}" itemLabel="#{category.name}"/>
+                              </p:selectOneMenu>
+                            </td>
+                            <td>
+                              <p:selectOneMenu
+                                widgetVar="alias_#{rowIndex}_#{missingRunTypeStatus.index}"
+                                value="#{runType.aliasTo}"
+                                styleClass="hidden"
+                              >
+                                <f:selectItems value="#{uploadedFile.dataFile.getRunTypeValuesWithExclusion(runType.runType)}" var="runTypeAlias"/>
+                              </p:selectOneMenu>
+                            </td>
+                          </tr>
+                        </ui:repeat>
+                      </table>
+                      <p:commandButton
+                        icon="ui-icon-save"
+                        actionListener="#{fileUpload.updateRunTypes(rowIndex)}"
+                        title="Save Run Types"
+                        value="Save Run Types"
+                        onclick="PF('runTypesDialog_#{rowIndex}').hide()"
+                        update="fileList"
+                        oncomplete="reprocessUploadedFiles()"
+                      />
+                    </p:fieldset>
+                    <p:fieldset legend="These run types are already defined">
+                      <table class="shrink noborder">
+                        <ui:repeat
+                          var="runType"
+                          value="#{uploadedFile.dataFile.fileDefinition.runTypes.values()}"
+                        >
+                          <tr>
+                            <td class="labels">
+                              <h:outputText value="#{runType.runType}"/>
+                            </td>
+                            <td>
+                              <h:outputText value="#{runType.assignmentText}"/>
+                            </td>
+                          </tr>
+                        </ui:repeat>
+                      </table>
+                    </p:fieldset>
+                  </p:dialog>
+                </ui:fragment>
+              </p:column>
+            </p:dataTable>
+          </p:outputPanel>
+        </div>
       </div>
       <h:panelGrid columns="1" cellpadding="5" class="buttonPanel">
         <p:commandButton id="storeFileButton"
-        styleClass="#{fileUpload.storeFileButtonClass}" icon="ui-icon-disk"
-            title="Store marked files to database"
-            value="Store marked files to database"
-            actionListener="#{fileUpload.store()}"
-            ajax="true" update="fileList"
-            action="file_list"
-            />
+          styleClass="#{fileUpload.storeFileButtonClass}" icon="ui-icon-disk"
+          title="Store marked files to database"
+          value="Store marked files to database"
+          actionListener="#{fileUpload.store()}"
+          ajax="true" update="fileList"
+          action="file_list"
+        />
         <p:button value="Back to File List" outcome="file_list"/>
       </h:panelGrid>
     </h:form>

--- a/WebApp/WebContent/instrument/new/run_types.xhtml
+++ b/WebApp/WebContent/instrument/new/run_types.xhtml
@@ -50,7 +50,7 @@
                 <table class="form">
                     <ui:repeat value="#{file.runTypeValues}" var="runType">
                       <tr>
-                        <td class="labels">#{runType}</td>
+                        <td class="labelsNoPad">#{runType}</td>
                         <td>
                           <p:selectOneMenu widgetVar="#{fileStatus.index}-#{runType}-menu" onchange="setRunTypeCategory('#{fileStatus.index}', '#{runType}')">
                             <f:selectItems value="#{newInstrumentBean.runTypeCategories}" var="category" itemValue="#{category.code}" itemLabel="#{category.name}"/>

--- a/WebApp/WebContent/instrument/new/run_types.xhtml
+++ b/WebApp/WebContent/instrument/new/run_types.xhtml
@@ -27,8 +27,10 @@
       <h:inputHidden id="assignCategoryFile" value="#{newInstrumentBean.runTypeAssignFile}"/>
       <h:inputHidden id="assignCategoryRunType" value="#{newInstrumentBean.runTypeAssignName}"/>
       <h:inputHidden id="assignCategoryCode" value="#{newInstrumentBean.runTypeAssignCode}"/>
+      <h:inputHidden id="assignAliasTo" value="#{newInstrumentBean.runTypeAssignAliasTo}"/>
+
       <p:commandLink id="assignCategoryLink" style="invisible" ajax="true" action="#{newInstrumentBean.assignRunTypeCategory}"
-        process="assignCategoryFile assignCategoryRunType assignCategoryCode" update="assignedCategories" oncomplete="renderAssignedCategories();"/>
+        process="assignCategoryFile assignCategoryRunType assignCategoryCode assignAliasTo" update="assignedCategories" oncomplete="renderAssignedCategories();"/>
 
 
       <p:fieldset id="categoriesPanel" legend="Run Type Categories" style="margin-bottom: 20px">
@@ -42,18 +44,23 @@
         </div>
 
         <div id="runTypeFiles">
-          <ui:repeat value="#{newInstrumentBean.instrumentFiles}" var="file">
+          <ui:repeat value="#{newInstrumentBean.instrumentFiles}" var="file" varStatus="fileStatus">
             <div class="runTypeFile">
               <p:fieldset legend="#{file.fileDescription}">
                 <table class="form">
                     <ui:repeat value="#{file.runTypeValues}" var="runType">
                       <tr>
-                          <td class="labels">#{runType}</td>
-                          <td>
-                            <p:selectOneMenu widgetVar="#{file.fileDescription}-#{runType}-menu" onchange="setRunTypeCategory('#{file.fileDescription}', '#{runType}', event.target.value)">
-                                <f:selectItems value="#{newInstrumentBean.runTypeCategories}" var="category" itemValue="#{category.code}" itemLabel="#{category.name}"/>
-                            </p:selectOneMenu>
-                          </td>
+                        <td class="labels">#{runType}</td>
+                        <td>
+                          <p:selectOneMenu widgetVar="#{fileStatus.index}-#{runType}-menu" onchange="setRunTypeCategory('#{fileStatus.index}', '#{runType}')">
+                            <f:selectItems value="#{newInstrumentBean.runTypeCategories}" var="category" itemValue="#{category.code}" itemLabel="#{category.name}"/>
+                          </p:selectOneMenu>
+                        </td>
+                        <td id="#{fileStatus.index}-#{runType}-aliasMenu" class="hidden">
+                          <p:selectOneMenu widgetVar="#{fileStatus.index}-#{runType}-alias" onchange="setRunTypeCategory('#{fileStatus.index}', '#{runType}')">
+                            <f:selectItems value="#{file.getRunTypeValuesWithExclusion(runType)}" var="runTypeAlias"/>
+                          </p:selectOneMenu>
+                        </td>
                     </tr>
                   </ui:repeat>
                 </table>

--- a/WebApp/WebContent/resources/script/dataFiles.js
+++ b/WebApp/WebContent/resources/script/dataFiles.js
@@ -26,8 +26,17 @@ function renderMessages(messages) {
   PF('msgDialog').show();
 }
 
-function reProcessUploadedFiles() {
+function reprocessUploadedFiles() {
   $('#uploadForm\\:fileList_data>tr').each(function() {
     extractNext();
   });
+}
+
+function runTypeChanged(rowIndex, runTypeIndex) {
+  var runType = PF('missingRunType_' + rowIndex + '_' + runTypeIndex).getSelectedValue();
+  if (runType == 'ALIAS') {
+    PF('alias_' + rowIndex + '_' + runTypeIndex).jq.show()
+  } else {
+    PF('alias_' + rowIndex + '_' + runTypeIndex).jq.hide()
+  }
 }

--- a/WebApp/WebContent/resources/script/newInstrument.js
+++ b/WebApp/WebContent/resources/script/newInstrument.js
@@ -3,6 +3,7 @@
 //************************************************
 
 allTimesOK = false;
+drawingPage = false;
 
 
 //************************************************
@@ -1210,11 +1211,25 @@ function removeFile(fileName) {
 * RUN TYPES PAGE
 *
 *******************************************************/
-function setRunTypeCategory(file, runType, category) {
-  $('#newInstrumentForm\\:assignCategoryFile').val(file);
-  $('#newInstrumentForm\\:assignCategoryRunType').val(runType);
-  $('#newInstrumentForm\\:assignCategoryCode').val(category);
-  $('#newInstrumentForm\\:assignCategoryLink').click();
+function setRunTypeCategory(fileIndex, runType) {
+
+  if (!drawingPage) {
+    var runTypeCategory = PF(fileIndex + '-' + runType + '-menu').getSelectedValue();
+    var aliasTo = null;
+
+    if (runTypeCategory == 'ALIAS') {
+      $('#' + fileIndex + '-' + runType + '-aliasMenu').show();
+      aliasTo = PF(fileIndex + '-' + runType + '-alias').getSelectedValue();
+    } else {
+      $('#' + fileIndex + '-' + runType + '-aliasMenu').hide();
+    }
+
+    $('#newInstrumentForm\\:assignCategoryFile').val(fileIndex);
+    $('#newInstrumentForm\\:assignCategoryRunType').val(runType);
+    $('#newInstrumentForm\\:assignCategoryCode').val(runTypeCategory);
+    $('#newInstrumentForm\\:assignAliasTo').val(aliasTo);
+    $('#newInstrumentForm\\:assignCategoryLink').click();
+  }
 }
 
 function renderAssignedCategories() {
@@ -1254,12 +1269,23 @@ function renderAssignedCategories() {
 }
 
 function populateRunTypeMenus() {
+  drawingPage = true;
   var runTypeAssignments = JSON.parse($('#newInstrumentForm\\:assignedRunTypes').val());
   for (var i = 0; i < runTypeAssignments.length; i++) {
     var file = runTypeAssignments[i];
 
     for (var j = 0; j < file['assignments'].length; j++) {
-      PF(file["file"] + "-" + file["assignments"][j]["runType"] + "-menu").selectValue(file["assignments"][j]["category"]);
+      var category = file["assignments"][j]["category"];
+      if (null == category) {
+        // Alias
+          PF(file["index"] + "-" + file["assignments"][j]["runType"] + "-menu").selectValue('ALIAS');
+        $('#' + file["index"] + '-' + file["assignments"][j]["runType"] + '-aliasMenu').show();
+        PF(file["index"] + "-" + file["assignments"][j]["runType"] + "-alias").selectValue(file["assignments"][j]["aliasTo"]);
+      } else {
+        PF(file["index"] + "-" + file["assignments"][j]["runType"] + "-menu").selectValue(category);
+        $('#' + file["index"] + '-' + file["assignments"][j]["runType"] + '-aliasMenu').hide();
+      }
     }
   }
+  drawingPage = false;
 }

--- a/WebApp/WebContent/resources/style/main.css
+++ b/WebApp/WebContent/resources/style/main.css
@@ -404,6 +404,12 @@ td.labels {
   font-weight: 700;
 }
 
+td.labelsNoPad {
+  text-align: right;
+  padding-right: 10px;
+  font-weight: 700;
+}
+
 table .numericCol {
   text-align: right;
 }

--- a/WebApp/WebContent/resources/style/main.css
+++ b/WebApp/WebContent/resources/style/main.css
@@ -393,6 +393,18 @@ div.fullPage {
   padding: 5px;
 }
 
+table.shrink {
+  table-layout: unset;
+}
+
+table.noborder {
+  border-width: 0px;
+}
+
+table.noborder td {
+  border-width: 0px;
+}
+
 table.form {
   width: 100%;
 }
@@ -700,6 +712,10 @@ table.fileDates {
 
 .ui-tabs .ui-tabs-nav li a.clickable {
   cursor: pointer;
+}
+
+.ui-datatable shrink {
+  width: unset;
 }
 
 @keyframes rowFlash {

--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Files/DataFile.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Files/DataFile.java
@@ -466,7 +466,7 @@ public class DataFile {
 
     if (runTypeColumn > -1) {
       loadContents();
-      runType = fileDefinition.getRunType(contents.get(line));
+      runType = fileDefinition.getRunType(contents.get(line), true);
     }
 
     return runType;

--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Files/DataFile.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Files/DataFile.java
@@ -16,7 +16,7 @@ import uk.ac.exeter.QuinCe.data.Instrument.MissingRunTypeException;
 import uk.ac.exeter.QuinCe.data.Instrument.DataFormats.DateTimeColumnAssignment;
 import uk.ac.exeter.QuinCe.data.Instrument.DataFormats.DateTimeSpecification;
 import uk.ac.exeter.QuinCe.data.Instrument.DataFormats.PositionException;
-import uk.ac.exeter.QuinCe.data.Instrument.RunTypes.RunType;
+import uk.ac.exeter.QuinCe.data.Instrument.RunTypes.RunTypeAssignment;
 import uk.ac.exeter.QuinCe.data.Instrument.RunTypes.RunTypeCategory;
 import uk.ac.exeter.QuinCe.utils.DatabaseUtils;
 import uk.ac.exeter.QuinCe.utils.HighlightedString;
@@ -94,11 +94,11 @@ public class DataFile {
   /**
    * Run types in this file not defined in the file definition
    */
-  private Set<RunType> missingRunTypes = new HashSet<>();
+  private Set<RunTypeAssignment> missingRunTypes = new HashSet<RunTypeAssignment>();
 
 
-  public List<RunType> getMissingRunTypes() {
-    List<RunType> list = new ArrayList<>(missingRunTypes);
+  public List<RunTypeAssignment> getMissingRunTypes() {
+    List<RunTypeAssignment> list = new ArrayList<>(missingRunTypes);
     Collections.sort(list);
     return list;
   }
@@ -691,5 +691,24 @@ public class DataFile {
     loadContents();
     String fieldValue = fileDefinition.extractFields(contents.get(line)).get(field);
     return extractDoubleFieldValue(fieldValue, missingValue);
+  }
+
+  /**
+   * Get the list of run type values with the specified value excluded.
+   * This list will include all the run types from the stored file
+   * definition plus any missing run types (except that specified
+   * as the exclusion).
+   * @param exclusion The value to exclude from the list
+   * @return The list of run types without the excluded value
+   */
+  public List<String> getRunTypeValuesWithExclusion(String exclusion) {
+    List<String> runTypeValues = fileDefinition.getRunTypeValues();
+    for (RunTypeAssignment runTypeAssignment : missingRunTypes) {
+      if (!runTypeAssignment.getRunType().equals(exclusion)) {
+        runTypeValues.add(runTypeAssignment.getRunType());
+      }
+    }
+
+    return runTypeValues;
   }
 }

--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Instrument/FileDefinition.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Instrument/FileDefinition.java
@@ -5,11 +5,12 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 
 import uk.ac.exeter.QuinCe.data.Instrument.DataFormats.DateTimeSpecification;
 import uk.ac.exeter.QuinCe.data.Instrument.DataFormats.LatitudeSpecification;
 import uk.ac.exeter.QuinCe.data.Instrument.DataFormats.LongitudeSpecification;
+import uk.ac.exeter.QuinCe.data.Instrument.RunTypes.RunTypeAssignment;
+import uk.ac.exeter.QuinCe.data.Instrument.RunTypes.RunTypeAssignments;
 import uk.ac.exeter.QuinCe.data.Instrument.RunTypes.RunTypeCategory;
 import uk.ac.exeter.QuinCe.data.Instrument.SensorDefinition.SensorAssignments;
 import uk.ac.exeter.QuinCe.data.Instrument.SensorDefinition.SensorType;
@@ -141,7 +142,7 @@ public class FileDefinition implements Comparable<FileDefinition> {
   /**
    * The list of run type values for the instrument
    */
-  protected TreeMap<String, RunTypeCategory> runTypes = null;
+  protected RunTypeAssignments runTypes = null;
 
   /**
    * The file set of which this definition is a member
@@ -542,7 +543,7 @@ public class FileDefinition implements Comparable<FileDefinition> {
    * {@code null}.
    * @return The run types
    */
-  public TreeMap<String, RunTypeCategory> getRunTypes() {
+  public RunTypeAssignments getRunTypes() {
     return runTypes;
   }
 
@@ -562,6 +563,17 @@ public class FileDefinition implements Comparable<FileDefinition> {
   }
 
   /**
+   * Get the list of run type values with the specified value excluded
+   * @param exclusion The value to exclude from the list
+   * @return The list of run types without the excluded value
+   */
+  public List<String> getRunTypeValuesWithExclusion(String exclusion) {
+    List<String> runTypeValues = getRunTypeValues();
+    runTypeValues.remove(exclusion);
+    return runTypeValues;
+  }
+
+  /**
    * Set the index of the column containing the run type
    * @param runTypeColumn The Run Type column
    */
@@ -577,7 +589,7 @@ public class FileDefinition implements Comparable<FileDefinition> {
     if (runTypeColumn == -1) {
       runTypes = null;
     } else {
-      runTypes = new TreeMap<String, RunTypeCategory>();
+      runTypes = new RunTypeAssignments();
     }
   }
 
@@ -601,7 +613,20 @@ public class FileDefinition implements Comparable<FileDefinition> {
    * @param category The run type category
    */
   public void setRunTypeCategory(String runType, RunTypeCategory category) {
-    runTypes.put(runType, category);
+    runTypes.put(runType, new RunTypeAssignment(runType, category));
+  }
+
+  /**
+   * Set the run type category for a given run type
+   * @param runType The run type
+   * @param category The run type category
+   */
+  public void setRunTypeCategory(String runType, String alias) {
+    // TODO We should check to make sure that the aliased run type actually exists
+    //      and that it's not a circular alias
+    //      I'm not sure how hard this is at the minute so I'm ignoring it -
+    //      the UI should prevent it from happening anyway
+    runTypes.put(runType, new RunTypeAssignment(runType, alias));
   }
 
   /**
@@ -787,6 +812,6 @@ public class FileDefinition implements Comparable<FileDefinition> {
    * @throws FileDefinitionException If the Run Type is not recognised
    */
   public RunTypeCategory getRunTypeCategory(String line) throws FileDefinitionException {
-    return runTypes.get(getRunType(line));
+    return runTypes.get(getRunType(line)).getCategory();
   }
 }

--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Instrument/FileDefinition.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Instrument/FileDefinition.java
@@ -783,7 +783,7 @@ public class FileDefinition implements Comparable<FileDefinition> {
    * @return The run type
    * @throws FileDefinitionException If this file does not contain run types, the run type is not present, or the run type is not recognised
    */
-  public String getRunType(String line) throws FileDefinitionException {
+  public String getRunType(String line, boolean followAlias) throws FileDefinitionException {
     String result = null;
 
     if (!hasRunTypes()) {
@@ -797,7 +797,16 @@ public class FileDefinition implements Comparable<FileDefinition> {
             + runTypeValue + " on instrument to load this file.",
             runTypeValue);
         } else {
-          result = runTypeValue;
+          if (!followAlias) {
+            result = runTypeValue;
+          } else {
+            RunTypeAssignment assignment = runTypes.get(runTypeValue);
+            while (assignment.isAlias()) {
+              assignment = runTypes.get(assignment.getAliasTo());
+            }
+
+            result = assignment.getRunType();
+          }
         }
       }
     }
@@ -812,6 +821,6 @@ public class FileDefinition implements Comparable<FileDefinition> {
    * @throws FileDefinitionException If the Run Type is not recognised
    */
   public RunTypeCategory getRunTypeCategory(String line) throws FileDefinitionException {
-    return runTypes.get(getRunType(line)).getCategory();
+    return runTypes.getRunTypeCategory(getRunType(line, true));
   }
 }

--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Instrument/InstrumentDB.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Instrument/InstrumentDB.java
@@ -92,7 +92,7 @@ public class InstrumentDB {
    * Query to get all the run types used in a given file definition
    */
   private static final String GET_FILE_RUN_TYPES_QUERY = "SELECT "
-      + "run_name, category_code "
+      + "run_name, category_code, alias_to "
       + "FROM run_type WHERE file_definition_id = ?";
 
   /**
@@ -942,8 +942,13 @@ public class InstrumentDB {
       while (records.next()) {
         String runType = records.getString(1);
         String categoryCode = records.getString(2);
+        String aliasTo = records.getString(3);
 
-        file.setRunTypeCategory(runType, runTypeConfig.getCategory(categoryCode));
+        if (categoryCode.equals(RunTypeCategory.ALIAS_CATEGORY.getCode())) {
+          file.setRunTypeCategory(runType, aliasTo);
+        } else {
+          file.setRunTypeCategory(runType, runTypeConfig.getCategory(categoryCode));
+        }
       }
 
     } catch (SQLException e) {

--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Instrument/MissingRunTypeException.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Instrument/MissingRunTypeException.java
@@ -2,7 +2,8 @@ package uk.ac.exeter.QuinCe.data.Instrument;
 
 import java.io.Serializable;
 
-import uk.ac.exeter.QuinCe.data.Instrument.RunTypes.RunType;
+import uk.ac.exeter.QuinCe.data.Instrument.RunTypes.RunTypeAssignment;
+import uk.ac.exeter.QuinCe.data.Instrument.RunTypes.RunTypeCategory;
 
 /**
  * Exception for missing run types in files.
@@ -17,9 +18,9 @@ public class MissingRunTypeException extends FileDefinitionException implements 
    */
   private static final long serialVersionUID = 790385140808465553L;
 
-  private RunType runType;
+  private RunTypeAssignment runType;
 
-  public RunType getRunType() {
+  public RunTypeAssignment getRunType() {
     return runType;
   }
 
@@ -29,6 +30,6 @@ public class MissingRunTypeException extends FileDefinitionException implements 
    */
   public MissingRunTypeException(String message, String runType) {
     super(message);
-    this.runType = new RunType(runType);
+    this.runType = new RunTypeAssignment(runType, RunTypeCategory.IGNORED_CATEGORY);
   }
 }

--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Instrument/RunTypes/RunTypeAssignment.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Instrument/RunTypes/RunTypeAssignment.java
@@ -48,7 +48,7 @@ public class RunTypeAssignment implements Comparable<RunTypeAssignment> {
    * @param runType The run type
    */
   public RunTypeAssignment(String runType) {
-    this.runType = runType;
+    this.runType = runType.toLowerCase();
     this.category = null;
   }
 
@@ -58,7 +58,7 @@ public class RunTypeAssignment implements Comparable<RunTypeAssignment> {
    * @param category The category
    */
   public RunTypeAssignment(String runType, RunTypeCategory category) {
-    this.runType = runType;
+    this.runType = runType.toLowerCase();
     this.category = category;
   }
 
@@ -68,7 +68,7 @@ public class RunTypeAssignment implements Comparable<RunTypeAssignment> {
    * @param aliasTo The run type to which is it aliased
    */
   public RunTypeAssignment(String runType, String aliasTo) {
-    this.runType = runType;
+    this.runType = runType.toLowerCase();
     this.category = null;
     this.alias = true;
     this.aliasTo = aliasTo;

--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Instrument/RunTypes/RunTypeAssignment.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Instrument/RunTypes/RunTypeAssignment.java
@@ -93,7 +93,12 @@ public class RunTypeAssignment implements Comparable<RunTypeAssignment> {
 
   /**
    * Get the category to which this run type is assigned.
-   * If the run type is an alias, the category will be {@code null}.
+   * If the run type is an alias, returned category will be
+   * {@code null}.
+   *
+   * If you want to get the aliased category of a run type,
+   * use {@link RunTypeAssignments#getRunTypeCategory(String)}
+   *
    * @return The assigned category
    */
   public RunTypeCategory getCategory() {

--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Instrument/RunTypes/RunTypeAssignment.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Instrument/RunTypes/RunTypeAssignment.java
@@ -1,5 +1,9 @@
 package uk.ac.exeter.QuinCe.data.Instrument.RunTypes;
 
+import java.util.List;
+
+import uk.ac.exeter.QuinCe.web.system.ResourceManager;
+
 /**
  * Stores details of the assignment of a given run type
  * to a run type category. Handles aliases to other run
@@ -16,12 +20,27 @@ package uk.ac.exeter.QuinCe.data.Instrument.RunTypes;
  */
 public class RunTypeAssignment implements Comparable<RunTypeAssignment> {
 
+  /**
+   * The run type name
+   */
   private String runType;
 
+  /**
+   * The category to which the run type is assigned.
+   * If the run type is an alias, this will be {@code null}.
+   */
   private RunTypeCategory category;
 
+  /**
+   * Indicates whether or not this run type
+   * is an alias to another run type
+   */
   private boolean alias = false;
 
+  /**
+   * The run type to which this run type is
+   * aliased. {@code null} if it is not an alias
+   */
   private String aliasTo = null;
 
   /**
@@ -90,12 +109,28 @@ public class RunTypeAssignment implements Comparable<RunTypeAssignment> {
   }
 
   /**
+   * Set the flag stating whether or not this run type is an alias
+   * @param alias The alias flag
+   */
+  public void setAlias(boolean alias) {
+    this.alias = alias;
+  }
+
+  /**
    * Get the run type to which this run type is aliased.
    * Returns {@code null} if this is not an alias
    * @return The alias
    */
   public String getAliasTo() {
     return aliasTo;
+  }
+
+  /**
+   * Set the run type to which this run type is aliased.
+   * @param aliasTo The alias
+   */
+  public void setAliasTo(String aliasTo) {
+    this.aliasTo = aliasTo;
   }
 
   @Override
@@ -134,5 +169,76 @@ public class RunTypeAssignment implements Comparable<RunTypeAssignment> {
   @Override
   public int hashCode() {
     return runType.hashCode();
+  }
+
+  /**
+   * Get a human readable description of this assignment
+   * @return The assignment description
+   */
+  public String getAssignmentText() {
+    StringBuilder result = new StringBuilder();
+
+    if (alias) {
+      result.append("Alias to ");
+      result.append(aliasTo);
+    } else {
+      result.append(category.getName());
+    }
+
+    return result.toString();
+  }
+
+  /**
+   * Get the code for the assigned Run Type category.
+   * If no category is assigned, returns {@code null}
+   * @return The assigned category
+   */
+  public String getCategoryCode() {
+    String result = null;
+
+    if (null != category) {
+      if (isAlias()) {
+        result = "ALIAS";
+      } else {
+        result = category.getCode();
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Set a run type
+   * @param code
+   * @throws RunTypeCategoryException If the code is not recognised
+   */
+  public void setCategoryCode(String code) throws RunTypeCategoryException {
+    boolean categoryAssigned = false;
+
+    if (code.equals(RunTypeCategory.ALIAS_CATEGORY.getCode())) {
+      category = null;
+      alias = true;
+      categoryAssigned = true;
+    } else {
+      try {
+        List<RunTypeCategory> categories = ResourceManager.getInstance().getRunTypeCategoryConfiguration().getCategories(true, true);
+        for (RunTypeCategory checkCategory : categories) {
+          if (checkCategory.getCode().equals(code)) {
+            category = checkCategory;
+            categoryAssigned = true;
+            break;
+          }
+        }
+      } catch (Exception e) {
+        e.printStackTrace();
+        throw e;
+      }
+    }
+
+    if (!categoryAssigned) {
+      RunTypeCategoryException e = new RunTypeCategoryException("Unrecognised run type '" + code + "'");
+      e.printStackTrace();
+      throw e;
+    }
   }
 }

--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Instrument/RunTypes/RunTypeAssignment.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Instrument/RunTypes/RunTypeAssignment.java
@@ -1,0 +1,138 @@
+package uk.ac.exeter.QuinCe.data.Instrument.RunTypes;
+
+/**
+ * Stores details of the assignment of a given run type
+ * to a run type category. Handles aliases to other run
+ * types.
+ *
+ * The category can be empty to show that the run type
+ * is not assigned to anything.
+ *
+ * The natural ordering of this class is the name of
+ * the run type.
+ *
+ * @author zuj007
+ *
+ */
+public class RunTypeAssignment implements Comparable<RunTypeAssignment> {
+
+  private String runType;
+
+  private RunTypeCategory category;
+
+  private boolean alias = false;
+
+  private String aliasTo = null;
+
+  /**
+   * Create an empty assignment for a run type
+   * @param runType The run type
+   */
+  public RunTypeAssignment(String runType) {
+    this.runType = runType;
+    this.category = null;
+  }
+
+  /**
+   * Construct a standard run type assignment to a category
+   * @param runType The run type
+   * @param category The category
+   */
+  public RunTypeAssignment(String runType, RunTypeCategory category) {
+    this.runType = runType;
+    this.category = category;
+  }
+
+  /**
+   * Create an alias from one run type to another
+   * @param runType The run type
+   * @param aliasTo The run type to which is it aliased
+   */
+  public RunTypeAssignment(String runType, String aliasTo) {
+    this.runType = runType;
+    this.category = null;
+    this.alias = true;
+    this.aliasTo = aliasTo;
+  }
+
+  /**
+   * Determine whether or not this run type is correctly assigned,
+   * either to a category or as an alias
+   * @return {@code true} if the run type is assigned; {@code false} if it is not
+   */
+  public boolean isAssigned() {
+    return (!alias && null == category);
+  }
+
+  /**
+   * Get the run type that this assignment is for
+   * @return The run type
+   */
+  public String getRunType() {
+    return runType;
+  }
+
+  /**
+   * Get the category to which this run type is assigned.
+   * If the run type is an alias, the category will be {@code null}.
+   * @return The assigned category
+   */
+  public RunTypeCategory getCategory() {
+    return category;
+  }
+
+  /**
+   * Determine whether or not this run type is an alias
+   * @return {@code true} if the run type is an alias; {@code false} if it is not
+   */
+  public boolean isAlias() {
+    return alias;
+  }
+
+  /**
+   * Get the run type to which this run type is aliased.
+   * Returns {@code null} if this is not an alias
+   * @return The alias
+   */
+  public String getAliasTo() {
+    return aliasTo;
+  }
+
+  @Override
+  public int compareTo(RunTypeAssignment o) {
+    return runType.compareTo(o.runType);
+  }
+
+  @Override
+  public String toString() {
+    String result;
+
+    if (alias) {
+      result = runType + " aliased to " + aliasTo;
+    } else if (null == category) {
+      result = runType + " not assigned";
+    } else {
+      result = runType + " assigned to " + category.getName();
+    }
+
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    boolean result;
+
+    if (!(o instanceof RunTypeAssignment)) {
+      result = false;
+    } else {
+      result = runType.equals(((RunTypeAssignment) o).runType);
+    }
+
+    return result;
+  }
+
+  @Override
+  public int hashCode() {
+    return runType.hashCode();
+  }
+}

--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Instrument/RunTypes/RunTypeAssignments.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Instrument/RunTypes/RunTypeAssignments.java
@@ -13,4 +13,35 @@ public class RunTypeAssignments extends TreeMap<String, RunTypeAssignment> {
     super();
   }
 
+  /**
+   * Automatically convert a key to match the internal Map
+   * If the key is a String, convert it to lower case.
+   * Otherwise leave it as it is
+   * @param key The key
+   * @return The converted key
+   */
+  private Object convertKey(Object key) {
+    Object result = key;
+
+    if (key instanceof String) {
+      result = ((String) key).toLowerCase();
+    }
+
+    return result;
+  }
+
+  @Override
+  public RunTypeAssignment put(String key, RunTypeAssignment assignment) {
+    return super.put(key.toLowerCase(), assignment);
+  }
+
+  @Override
+  public RunTypeAssignment get(Object key) {
+    return super.get(convertKey(key));
+  }
+
+  @Override
+  public boolean containsKey(Object key) {
+    return super.containsKey(convertKey(key));
+  }
 }

--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Instrument/RunTypes/RunTypeAssignments.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Instrument/RunTypes/RunTypeAssignments.java
@@ -1,0 +1,16 @@
+package uk.ac.exeter.QuinCe.data.Instrument.RunTypes;
+
+import java.util.TreeMap;
+
+/**
+ * Holder for a set of run type assignments for a file
+ * @author zuj007
+ *
+ */
+public class RunTypeAssignments extends TreeMap<String, RunTypeAssignment> {
+
+  public RunTypeAssignments() {
+    super();
+  }
+
+}

--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Instrument/RunTypes/RunTypeAssignments.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Instrument/RunTypes/RunTypeAssignments.java
@@ -30,6 +30,29 @@ public class RunTypeAssignments extends TreeMap<String, RunTypeAssignment> {
     return result;
   }
 
+  /**
+   * Get the category to which the specified run type is assigned.
+   * If the run type is an alias, category of the run type
+   * to which the specified type is aliased will be returned.
+   *
+   * If the specified run type is not found, {@code null} is returned.
+   *
+   * @return The assigned category
+   */
+  public RunTypeCategory getRunTypeCategory(String runType) {
+    RunTypeCategory result = null;
+
+    RunTypeAssignment assignment = get(runType);
+    if (null != assignment) {
+      result = assignment.getCategory();
+      if (assignment.isAlias()) {
+        result = getRunTypeCategory(assignment.getAliasTo());
+      }
+    }
+
+    return result;
+  }
+
   @Override
   public RunTypeAssignment put(String key, RunTypeAssignment assignment) {
     return super.put(key.toLowerCase(), assignment);

--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Instrument/RunTypes/RunTypeCategory.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Instrument/RunTypes/RunTypeCategory.java
@@ -28,6 +28,11 @@ public class RunTypeCategory implements Comparable<RunTypeCategory> {
   public static RunTypeCategory EXTERNAL_STANDARD_CATEGORY = null;
 
   /**
+   * The special ALIAS run type category
+   */
+  public static RunTypeCategory ALIAS_CATEGORY = null;
+
+  /**
    * The category code
    */
   private String code;
@@ -53,6 +58,7 @@ public class RunTypeCategory implements Comparable<RunTypeCategory> {
   static {
     try {
       IGNORED_CATEGORY = new RunTypeCategory("IGN", "IGNORED", 0, 0);
+      ALIAS_CATEGORY = new RunTypeCategory("ALIAS", "Alias", 0, 0);
       EXTERNAL_STANDARD_CATEGORY = new RunTypeCategory("EXT", "External Standard", 1, 0);
     } catch (InvalidCategoryTypeException e) {
       // Do nothing

--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Instrument/RunTypes/RunTypeCategoryConfiguration.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Instrument/RunTypes/RunTypeCategoryConfiguration.java
@@ -124,12 +124,16 @@ public class RunTypeCategoryConfiguration {
    * @param includeIgnored Specifies whether the IGNORED category should be included
    * @return The run type categories
    */
-  public List<RunTypeCategory> getCategories(boolean includeIgnored) {
+  public List<RunTypeCategory> getCategories(boolean includeIgnored, boolean includeAlias) {
     List<RunTypeCategory> result = new ArrayList<RunTypeCategory>(categories);
     result.add(RunTypeCategory.EXTERNAL_STANDARD_CATEGORY);
 
     if (includeIgnored) {
       result.add(RunTypeCategory.IGNORED_CATEGORY);
+    }
+
+    if (includeAlias) {
+      result.add(RunTypeCategory.ALIAS_CATEGORY);
     }
 
     return result;
@@ -147,6 +151,8 @@ public class RunTypeCategoryConfiguration {
 
     if (categoryCode.equalsIgnoreCase(RunTypeCategory.IGNORED_CATEGORY.getCode())) {
       result = RunTypeCategory.IGNORED_CATEGORY;
+    } else if (categoryCode.equalsIgnoreCase(RunTypeCategory.ALIAS_CATEGORY.getCode())) {
+        result = RunTypeCategory.ALIAS_CATEGORY;
     } else if (categoryCode.equalsIgnoreCase(RunTypeCategory.EXTERNAL_STANDARD_CATEGORY.getCode())) {
       result = RunTypeCategory.EXTERNAL_STANDARD_CATEGORY;
     } else {

--- a/WebApp/src/uk/ac/exeter/QuinCe/web/BaseManagedBean.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/web/BaseManagedBean.java
@@ -14,9 +14,12 @@ import uk.ac.exeter.QuinCe.User.UserPreferences;
 import uk.ac.exeter.QuinCe.data.Instrument.Instrument;
 import uk.ac.exeter.QuinCe.data.Instrument.InstrumentDB;
 import uk.ac.exeter.QuinCe.data.Instrument.InstrumentStub;
+import uk.ac.exeter.QuinCe.data.Instrument.RunTypes.RunTypeCategory;
 import uk.ac.exeter.QuinCe.utils.StringUtils;
 import uk.ac.exeter.QuinCe.web.User.LoginBean;
+import uk.ac.exeter.QuinCe.web.system.ResourceException;
 import uk.ac.exeter.QuinCe.web.system.ResourceManager;
+import uk.ac.exeter.QuinCe.web.system.ServletUtils;
 
 /**
  * Several Managed Beans are used in the QuinCe application. This abstract class provides a
@@ -117,7 +120,7 @@ public abstract class BaseManagedBean {
    * @return The parameter value
    */
   public String getRequestParameter(String paramName) {
-    return (String) FacesContext.getCurrentInstance().getExternalContext().getRequestParameterMap().get(paramName);
+    return FacesContext.getCurrentInstance().getExternalContext().getRequestParameterMap().get(paramName);
   }
 
   /**
@@ -365,5 +368,14 @@ public abstract class BaseManagedBean {
    */
   public void setForceInstrumentReload(boolean forceReload) {
     this.forceInstrumentReload = forceReload;
+  }
+
+  /**
+   * Get the list of available run type categories
+   * @return The run type categories
+   * @throws ResourceException If the Resource Manager cannot be accessed
+   */
+  public List<RunTypeCategory> getRunTypeCategories() throws ResourceException {
+    return ServletUtils.getResourceManager().getRunTypeCategoryConfiguration().getCategories(true, true);
   }
 }

--- a/WebApp/src/uk/ac/exeter/QuinCe/web/Instrument/newInstrument/NewInstrumentBean.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/web/Instrument/newInstrument/NewInstrumentBean.java
@@ -44,9 +44,7 @@ import uk.ac.exeter.QuinCe.web.FileUploadBean;
 import uk.ac.exeter.QuinCe.web.Instrument.InstrumentListBean;
 import uk.ac.exeter.QuinCe.web.datasets.DataSetsBean;
 import uk.ac.exeter.QuinCe.web.files.DataFilesBean;
-import uk.ac.exeter.QuinCe.web.system.ResourceException;
 import uk.ac.exeter.QuinCe.web.system.ResourceManager;
-import uk.ac.exeter.QuinCe.web.system.ServletUtils;
 
 /**
  * Bean for collecting data about a new instrument
@@ -1429,15 +1427,6 @@ public class NewInstrumentBean extends FileUploadBean {
    */
   public String goToOtherInfo() {
     return NAV_OTHER_INFO;
-  }
-
-  /**
-   * Get the list of available run type categories
-   * @return The run type categories
-   * @throws ResourceException If the Resource Manager cannot be accessed
-   */
-  public List<RunTypeCategory> getRunTypeCategories() throws ResourceException {
-    return ServletUtils.getResourceManager().getRunTypeCategoryConfiguration().getCategories(true, true);
   }
 
   /**

--- a/WebApp/src/uk/ac/exeter/QuinCe/web/ServletUtilsBean.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/web/ServletUtilsBean.java
@@ -37,13 +37,14 @@ public class ServletUtilsBean{
         .getApplication().getELResolver()
         .getValue(elContext, null, "global");
   }
+
   /**
    * Shorthand to retrieve the run type categories from the configuration
    * @return
    * @throws ResourceException
    */
   public List<RunTypeCategory> getRunTypeCategories() throws ResourceException {
-    return ServletUtils.getResourceManager().getRunTypeCategoryConfiguration().getCategories(true);
+    return ServletUtils.getResourceManager().getRunTypeCategoryConfiguration().getCategories(true, true);
   }
 
   public RunTypeCategory getRunTypeCategory(String runTypeCategoryCode) throws ResourceException {

--- a/WebApp/src/uk/ac/exeter/QuinCe/web/files/UploadedDataFile.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/web/files/UploadedDataFile.java
@@ -22,27 +22,62 @@ import uk.ac.exeter.QuinCe.data.Files.DataFileMessage;
  *
  */
 public class UploadedDataFile {
+
+  /**
+   * The uploaded file
+   */
   private UploadedFile uploadedFile;
+
+  /**
+   * Indicates whether or not the file should be stored
+   */
   private boolean store = true;
+
+  /**
+   * The processed file
+   */
   private DataFile dataFile = null;
+
+  /**
+   * Error messages for the file
+   */
   private ArrayList<FacesMessage> messages = new ArrayList<>();
 
+  /**
+   * Indicates whether or not the file has been
+   * extracted and processed
+   */
+  private boolean processed = false;
+
+  /**
+   * Basic constructor - reads the file contents ready for processing
+   * @param file The uploaded file
+   */
   public UploadedDataFile(UploadedFile file) {
     setUploadedFile(file);
   }
+
   /**
-   * @return the uploadedFile
+   * Get the uploaded file
+   * @return The uploaded file
    */
   public UploadedFile getUploadedFile() {
     return uploadedFile;
   }
+
   /**
+   * Assign the uploaded file and extract its contents
    * @param uploadedFile the uploadedFile to set
    */
   public void setUploadedFile(UploadedFile uploadedFile) {
     this.uploadedFile = uploadedFile;
-    String[] fileLines = getLines();
+    getLines();
   }
+
+  /**
+   * Extract the file contents as individual lines
+   * @return The file lines
+   */
   public String[] getLines() {
     String fileContent = new String(uploadedFile.getContents(), StandardCharsets.UTF_8);
     if (null == fileContent || fileContent.trim().length() == 0) {
@@ -52,7 +87,8 @@ public class UploadedDataFile {
   }
 
   /**
-   * @return the base file name
+   * Get the filename of the file
+   * @return The filename
    */
   public String getName() {
     return uploadedFile.getFileName();
@@ -116,31 +152,6 @@ public class UploadedDataFile {
   }
 
   /**
-   * @return the messageClass
-   */
-  public String getMessageClass() {
-    String messageClass = "";
-    Severity level = null;
-    for (FacesMessage message: messages) {
-      if (level == null || message.getSeverity().compareTo(level) > 0) {
-        level = message.getSeverity();
-      }
-    }
-    messageClass = getSeverityLabel(level);
-    if ("".equals(messageClass) && dataFile != null && dataFile.getMessages().size() > 0) {
-      messageClass = getSeverityLabel(FacesMessage.SEVERITY_INFO);
-    }
-    return messageClass;
-  }
-
-  public String getMissingRunTypeClass() {
-    if (null != dataFile && dataFile.getMissingRunTypes().size() > 0) {
-      return "shown";
-    }
-    return "hidden";
-  }
-
-  /**
    * @param summary
    * @param severityError
    */
@@ -193,5 +204,40 @@ public class UploadedDataFile {
       severityClass = "info";
     }
     return severityClass;
+  }
+
+  /**
+   * Determine whether or not this file has been extraced
+   * and processed.
+   * @return {@code true} if the file has been processed; {@code false} if it has not
+   */
+  public boolean isProcessed() {
+    return processed;
+  }
+
+  /**
+   * Set the flag indicating whether or not the file has been processed
+   * @param processed The processed flag
+   */
+  public void setProcessed(boolean processed) {
+    this.processed = processed;
+  }
+
+  /**
+   * Determine whether or not error messages have been
+   * generated for this file
+   * @return {@code true} if there are messages; {@code false} if there are none
+   */
+  public boolean getHasMessages() {
+    return null != messages && messages.size() > 0;
+  }
+
+  /**
+   * Determine whether or not unrecognised run types have been detected
+   * in the file
+   * @return {@code true} if unrecognised run types have been found; {@code false} otherwise
+   */
+  public boolean getHasUnrecognisedRunTypes() {
+    return null != dataFile && dataFile.getMissingRunTypes().size() > 0;
   }
 }

--- a/src/migrations/db_migrations/V6__runtype_aliases.sql
+++ b/src/migrations/db_migrations/V6__runtype_aliases.sql
@@ -1,0 +1,2 @@
+# Add column to the run types table to support aliases
+ALTER TABLE `run_type` ADD `alias_to` VARCHAR(50) NULL DEFAULT NULL AFTER `category_code`;


### PR DESCRIPTION
Aliases for run types can be defined during instrument definition and during file upload (with unrecognised run types).

During data extraction, aliased run types are renamed to the base run type on which they are based.

Close #817 
Close #764 