### PR TITLE
(#879) Do not reuse statements when extracting dataset data

### DIFF
--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Calculation/CalculationDB.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Calculation/CalculationDB.java
@@ -39,12 +39,6 @@ import uk.ac.exeter.QuinCe.web.system.ResourceManager;
 public abstract class CalculationDB {
 
   /**
-   * The statement for inserting a new calculation record.
-   * Created as required by {@link #createCalculationRecord(Connection, long)}.
-   */
-  private PreparedStatement insertStatement = null;
-
-  /**
    * Get the name of the database table where calculation data is stored
    * @return The table name
    */
@@ -62,8 +56,10 @@ public abstract class CalculationDB {
     MissingParam.checkMissing(conn, "conn");
     MissingParam.checkZeroPositive(measurementId, "measurementId");
 
+    PreparedStatement statement = null;
+
     try {
-      PreparedStatement statement = getInsertStatement(conn);
+      statement = getInsertStatement(conn);
 
       statement.setLong(1, measurementId);
       statement.setInt(2, Flag.VALUE_NOT_SET);
@@ -75,6 +71,8 @@ public abstract class CalculationDB {
 
     } catch (SQLException e) {
       throw new DatabaseException("Error while creating calculation record", e);
+    } finally {
+      DatabaseUtils.closeStatements(statement);
     }
   }
 
@@ -87,19 +85,15 @@ public abstract class CalculationDB {
    */
   private PreparedStatement getInsertStatement(Connection conn) throws MissingParamException, SQLException {
 
-    if (null == insertStatement) {
-      List<String> fields = new ArrayList<String>();
+    List<String> fields = new ArrayList<String>();
 
-      fields.add("measurement_id");
-      fields.add("auto_flag");
-      fields.add("auto_message");
-      fields.add("user_flag");
-      fields.add("user_message");
+    fields.add("measurement_id");
+    fields.add("auto_flag");
+    fields.add("auto_message");
+    fields.add("user_flag");
+    fields.add("user_message");
 
-      insertStatement = DatabaseUtils.createInsertStatement(conn, getCalculationTable(), fields);
-    }
-
-    return insertStatement;
+    return DatabaseUtils.createInsertStatement(conn, getCalculationTable(), fields);
   }
 
   /**

--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Dataset/CalibrationDataDB.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Dataset/CalibrationDataDB.java
@@ -110,7 +110,7 @@ public class CalibrationDataDB {
    * @throws DatabaseException If a database error occurs
    * @throws NoSuchCategoryException If the record's Run Type is not recognised
    */
-  public static PreparedStatement storeCalibrationRecord(Connection conn, DataSetRawDataRecord record, PreparedStatement statement) throws MissingParamException, DataSetException, DatabaseException, NoSuchCategoryException {
+  public static PreparedStatement storeCalibrationRecord(Connection conn, DataSetRawDataRecord record) throws MissingParamException, DataSetException, DatabaseException, NoSuchCategoryException {
 
     MissingParam.checkMissing(conn, "conn");
     MissingParam.checkMissing(record, "record");
@@ -119,10 +119,10 @@ public class CalibrationDataDB {
       throw new DataSetException("Record is not a calibration record");
     }
 
+    PreparedStatement statement = null;
+
     try {
-      if (null == statement) {
-        statement = DatabaseUtils.createInsertStatement(conn, "calibration_data", createAllFieldsList());
-      }
+      statement = DatabaseUtils.createInsertStatement(conn, "calibration_data", createAllFieldsList());
 
       statement.setLong(1, record.getDatasetId());
       statement.setLong(2, DateTimeUtils.dateToLong(record.getDate()));
@@ -147,6 +147,8 @@ public class CalibrationDataDB {
       statement.execute();
     } catch (SQLException e) {
       throw new DatabaseException("Error storing dataset record", e);
+    } finally {
+      DatabaseUtils.closeStatements(statement);
     }
 
     return statement;

--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Dataset/DataSetDataDB.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Dataset/DataSetDataDB.java
@@ -116,7 +116,7 @@ public class DataSetDataDB {
    * @throws DatabaseException If a database error occurs
    * @throws NoSuchCategoryException If the record's Run Type is not recognised
    */
-  public static PreparedStatement storeRecord(Connection conn, DataSetRawDataRecord record, PreparedStatement datasetDataStatement) throws MissingParamException, DataSetException, DatabaseException, NoSuchCategoryException {
+  public static void storeRecord(Connection conn, DataSetRawDataRecord record) throws MissingParamException, DataSetException, DatabaseException, NoSuchCategoryException {
 
     MissingParam.checkMissing(conn, "conn");
     MissingParam.checkMissing(record, "record");
@@ -126,6 +126,7 @@ public class DataSetDataDB {
     }
 
     ResultSet createdKeys = null;
+    PreparedStatement datasetDataStatement = null;
 
     try {
       if (null == datasetDataStatement) {
@@ -165,10 +166,9 @@ public class DataSetDataDB {
     } catch (SQLException e) {
       throw new DatabaseException("Error storing dataset record", e);
     } finally {
+      DatabaseUtils.closeStatements(datasetDataStatement);
       DatabaseUtils.closeResultSets(createdKeys);
     }
-
-    return datasetDataStatement;
   }
 
   /**

--- a/WebApp/src/uk/ac/exeter/QuinCe/jobs/files/ExtractDataSetJob.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/jobs/files/ExtractDataSetJob.java
@@ -1,7 +1,6 @@
 package uk.ac.exeter.QuinCe.jobs.files;
 
 import java.sql.Connection;
-import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
@@ -72,10 +71,6 @@ public class ExtractDataSetJob extends Job {
 
     Connection conn = null;
 
-    // The statements for measurements and calibrations can be re-used for each record
-    PreparedStatement storeMeasurementStatement = null;
-    PreparedStatement storeCalibrationStatement = null;
-
     try {
       conn = dataSource.getConnection();
       conn.setAutoCommit(false);
@@ -98,9 +93,9 @@ public class ExtractDataSetJob extends Job {
       DataSetRawDataRecord record = rawData.getNextRecord();
       while (null != record) {
         if (record.isMeasurement()) {
-          storeMeasurementStatement = DataSetDataDB.storeRecord(conn, record, storeMeasurementStatement);
+          DataSetDataDB.storeRecord(conn, record);
         } else if (record.isCalibration()) {
-          storeCalibrationStatement = CalibrationDataDB.storeCalibrationRecord(conn, record, storeCalibrationStatement);
+          CalibrationDataDB.storeCalibrationRecord(conn, record);
         }
 
         // Read the next record
@@ -128,7 +123,6 @@ public class ExtractDataSetJob extends Job {
       }
       throw new JobFailedException(id, e);
     } finally {
-      DatabaseUtils.closeStatements(storeMeasurementStatement, storeCalibrationStatement);
       DatabaseUtils.closeConnection(conn);
     }
   }


### PR DESCRIPTION
There was a lot of statement reuse in the process of extracting data from the source files into the database, and some ended up being reused after they'd been closed. The reuse has been removed completely as it's the safest approach - we can assess performance later if required.

**NB** depends on #881 (fixing #817) - do that one first.

Close #879 
