### PR TITLE
(#585/#864) Check external standards on dataset creation

### DIFF
--- a/WebApp/WebContent/dataset/new_dataset.xhtml
+++ b/WebApp/WebContent/dataset/new_dataset.xhtml
@@ -21,6 +21,7 @@
   <ui:define name="content">
     <h:form id="uploadForm" method="post" charset="utf8">
       <f:passThroughAttribute name="data-valid-calibration" value="#{dataSetsBean.validCalibration}" />
+      <f:passThroughAttribute name="data-valid-calibration-message" value="#{dataSetsBean.validCalibrationMessage}" />
       <div class="fullPage">
         <div id="timelineContainer"></div>
         <script>

--- a/WebApp/WebContent/resources/script/dataSets.js
+++ b/WebApp/WebContent/resources/script/dataSets.js
@@ -62,11 +62,11 @@ function validateNewDataSet() {
 
   var result = true;
   var errorString = null;
-  const validCalibration = $('#uploadForm').data('validCalibration')
+  const validCalibration = $('#uploadForm').data('validCalibration');
 
   // Check that there is a valid calibration for the selected start time
   if (!validCalibration) {
-    errorString = 'Data set is missing a valid calibration';
+    errorString = $('#uploadForm').data('validCalibrationMessage');
   }
 
   // Check that there is a data set name


### PR DESCRIPTION
When the user creates a data set, additional checks are added to the check for valid sensor calibrations:

1. A complete set of external standards is available
2. At least one of the external standards has a concentration of zero

Close #585 
Close #864 
