### PR TITLE
(#819) Admin users can see all instruments

### DIFF
--- a/WebApp/WebContent/data_file/file_list.xhtml
+++ b/WebApp/WebContent/data_file/file_list.xhtml
@@ -29,7 +29,7 @@
         </h:panelGrid>
 
         <p:dataTable id="files" value="#{dataFilesBean.listFiles}" var="file"
-            styleClass="pageTable">
+            styleClass="pageBlock">
           <p:column>
             <f:facet name="header">
               <h:outputText value="Filename"/>

--- a/WebApp/WebContent/dataset/dataset_list.xhtml
+++ b/WebApp/WebContent/dataset/dataset_list.xhtml
@@ -84,7 +84,7 @@
         <p:remoteCommand name="updateList" update="datasets" actionListener="#{dataSetsBean.updateDatasetList}"/>
 
         <p:dataTable id="datasets" value="#{dataSetsBean.dataSets}"
-            var="dataset" styleClass="pageTable">
+            var="dataset" styleClass="pageBlock">
           <p:column>
             <f:facet name="header">
               <h:outputText value="Name"/>

--- a/WebApp/WebContent/instrument/external_standards.xhtml
+++ b/WebApp/WebContent/instrument/external_standards.xhtml
@@ -51,7 +51,7 @@
       <div class="sectionTitle">
         Current Deployments
       </div>
-      <p:dataTable styleClass="pageTable" var="calibration" value="#{externalStandardsBean.currentCalibrations}">
+      <p:dataTable styleClass="pageBlock" var="calibration" value="#{externalStandardsBean.currentCalibrations}">
         <p:column headerText="External Standard">
           <h:outputText value="#{calibration.target}"/>
         </p:column>
@@ -62,7 +62,7 @@
           <h:outputText value="#{calibration.humanReadableCoefficients}"/>
         </p:column>
       </p:dataTable>
-      <p:messages styleClass="pageTable"/>
+      <p:messages styleClass="pageBlock"/>
       <h:panelGrid columns="1" styleClass="buttonPanel">
         <p:commandButton value="Back to Instruments List" action="/instrument/instrument_list.xhtml"/>
       </h:panelGrid>

--- a/WebApp/WebContent/instrument/instrument_list.xhtml
+++ b/WebApp/WebContent/instrument/instrument_list.xhtml
@@ -39,7 +39,7 @@
         <p:commandButton value="Add New Instrument" ajax="false" action="#{newInstrumentBean.start}"/>
       </h:panelGrid>
 
-      <p:dataTable id="instruments" var="instrument" value="#{instrumentListBean.instrumentList}" styleClass="pageTable">
+      <p:dataTable id="instruments" var="instrument" value="#{instrumentListBean.instrumentList}" styleClass="pageBlock">
         <p:column>
           <f:facet name="header">Instrument Name</f:facet>
           <b><h:outputText value="#{instrument.name}"/></b>

--- a/WebApp/WebContent/instrument/sensor_calibrations.xhtml
+++ b/WebApp/WebContent/instrument/sensor_calibrations.xhtml
@@ -57,7 +57,7 @@
       <div class="sectionTitle">
         Current Calibrations
       </div>
-      <p:dataTable styleClass="pageTable" var="calibration" value="#{sensorCalibrationsBean.currentCalibrations}">
+      <p:dataTable styleClass="pageBlock" var="calibration" value="#{sensorCalibrationsBean.currentCalibrations}">
         <p:column headerText="Sensor">
           <h:outputText value="#{calibration.target}"/>
         </p:column>
@@ -68,7 +68,7 @@
           <h:outputText value="#{calibration.humanReadableCoefficients}"/>
         </p:column>
       </p:dataTable>
-      <p:messages styleClass="pageTable"/>
+      <p:messages styleClass="pageBlock"/>
       <h:panelGrid columns="1" styleClass="buttonPanel">
         <p:commandButton value="Back to Instruments List" action="/instrument/instrument_list.xhtml"/>
       </h:panelGrid>

--- a/WebApp/WebContent/resources/style/main.css
+++ b/WebApp/WebContent/resources/style/main.css
@@ -617,11 +617,10 @@ table.fileDates {
   font-family: 'Inconsolata', monospace;
 }
 
-.pageTable {
+.pageBlock {
   width: 75%;
   margin-left: auto;
   margin-right: auto;
-  min-height: 450px;
 }
 
 .centeredCell {

--- a/WebApp/src/uk/ac/exeter/QuinCe/User/User.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/User/User.java
@@ -15,11 +15,6 @@ import uk.ac.exeter.QuinCe.utils.MissingParamException;
 public class User {
 
   /**
-   * Permissions bit for job managers
-   */
-  public static final int BIT_JOB_MANAGER = 1;
-
-  /**
    * Permissions bit for administrators
    */
   public static final int BIT_ADMIN_USER = 1;
@@ -210,7 +205,7 @@ public class User {
    * @return {@code true} if this user is a job manager; {@code false} if not
    */
   public boolean getJobManager() {
-    return (permissions & BIT_JOB_MANAGER) > 0;
+    return isAdminUser();
   }
 
   /**

--- a/WebApp/src/uk/ac/exeter/QuinCe/User/User.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/User/User.java
@@ -20,6 +20,11 @@ public class User {
   public static final int BIT_JOB_MANAGER = 1;
 
   /**
+   * Permissions bit for administrators
+   */
+  public static final int BIT_ADMIN_USER = 1;
+
+  /**
    * The user's database record ID
    */
   private int databaseId;
@@ -214,5 +219,13 @@ public class User {
    */
   public UserPreferences getPreferences() {
     return preferences;
+  }
+
+  /**
+   * Determine whether or not this is an administrator user
+   * @return {@code true} if this user is an administrator; {@code false} if not
+   */
+  public boolean isAdminUser() {
+    return (permissions & BIT_ADMIN_USER) > 0;
   }
 }

--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Instrument/InstrumentDB.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Instrument/InstrumentDB.java
@@ -105,12 +105,23 @@ public class InstrumentDB {
   /**
    * Query for retrieving the list of instruments owned by a particular user
    */
-  private static final String GET_INSTRUMENT_LIST_QUERY = "SELECT i.id, i.name, SUM(c.post_calibrated) "
+  private static final String GET_SINGLE_USER_INSTRUMENT_LIST_QUERY = "SELECT i.id, i.name, SUM(c.post_calibrated) "
       + "FROM instrument AS i "
       + "INNER JOIN file_definition AS d ON i.id = d.instrument_id "
       + "INNER JOIN file_column AS c ON d.id = c.file_definition_id "
       + "WHERE i.owner = ? "
       + "GROUP BY i.id ORDER BY i.name ASC";
+
+  /**
+   * Query for retrieving the list of all instruments in the system, grouped by owner
+   */
+  private static final String GET_ALL_USERS_INSTRUMENT_LIST_QUERY = "SELECT "
+      + "i.id, CONCAT(u.surname, \", \", u.firstname, \" - \", i.name) AS name, SUM(c.post_calibrated) "
+      + "FROM instrument AS i "
+      + "INNER JOIN file_definition AS d ON i.id = d.instrument_id "
+      + "INNER JOIN file_column AS c ON d.id = c.file_definition_id "
+      + "INNER JOIN user AS u ON i.owner = u.id "
+      + "GROUP BY i.id ORDER BY name ASC";
 
   /**
    * Query for retrieving the stub for a specific instrument
@@ -409,6 +420,9 @@ public class InstrumentDB {
    * The list contains {@link InstrumentStub} objects, which just contain
    * the details required for lists of instruments in the UI.
    *
+   * If the specified owner is an administrator, the returned list
+   * will contain all instruments in the system
+   *
    * The list is ordered by the name of the instrument.
    *
    * @param dataSource A data source
@@ -423,15 +437,99 @@ public class InstrumentDB {
     MissingParam.checkMissing(owner, "owner");
 
     Connection conn = null;
-    PreparedStatement stmt = null;
-    ResultSet instruments = null;
-    List<InstrumentStub> instrumentList = new ArrayList<InstrumentStub>();
+    List<InstrumentStub> result = null;
 
     try {
       conn = dataSource.getConnection();
-      stmt = conn.prepareStatement(GET_INSTRUMENT_LIST_QUERY);
-      stmt.setLong(1, owner.getDatabaseID());
 
+      if (owner.isAdminUser()) {
+        result = getAllUsersInstrumentList(conn);
+      } else {
+        result = getInstrumentList(conn, owner.getDatabaseID());
+      }
+    } catch (SQLException e) {
+      throw new DatabaseException("Error retrieving instrument list", e);
+    }
+
+    return result;
+  }
+
+  /**
+   * Get the list of instruments for a single user.
+   *
+   * See {@link #getInstrumentList(DataSource, User)}
+   *
+   * @param conn A database connection
+   * @param ownerId The user's database ID
+   * @return The list of instruments
+   * @throws MissingParamException If any required parameters are missing
+   * @throws DatabaseException If a database error occurred
+   */
+  private static List<InstrumentStub> getInstrumentList(Connection conn, long ownerId) throws MissingParamException, DatabaseException {
+
+    PreparedStatement stmt = null;
+    List<InstrumentStub> instrumentList = null;
+
+    try {
+      stmt = conn.prepareStatement(GET_SINGLE_USER_INSTRUMENT_LIST_QUERY);
+      stmt.setLong(1, ownerId);
+      instrumentList = runInstrumentListQuery(conn,stmt);
+    } catch (SQLException e) {
+      throw new DatabaseException("Error while retrieving instrument list", e);
+    } finally {
+      DatabaseUtils.closeStatements(stmt);
+    }
+
+    return instrumentList;
+  }
+
+  /**
+   * Get the list of instruments for a single user.
+   *
+   * See {@link #getInstrumentList(DataSource, User)}
+   *
+   * @param conn A database connection
+   * @param ownerId The user's database ID
+   * @return The list of instruments
+   * @throws MissingParamException If any required parameters are missing
+   * @throws DatabaseException If a database error occurred
+   */
+  private static List<InstrumentStub> getAllUsersInstrumentList(Connection conn) throws MissingParamException, DatabaseException {
+
+    PreparedStatement stmt = null;
+    List<InstrumentStub> instrumentList = null;
+
+    try {
+      stmt = conn.prepareStatement(GET_ALL_USERS_INSTRUMENT_LIST_QUERY);
+      instrumentList = runInstrumentListQuery(conn, stmt);
+    } catch (SQLException e) {
+      throw new DatabaseException("Error while retrieving instrument list", e);
+    } finally {
+      DatabaseUtils.closeStatements(stmt);
+    }
+
+    return instrumentList;
+  }
+
+  /**
+   * Run a query to get a list of instruments. The query must produce three columns:
+   *
+   * <ol>
+   *   <li>Instrument ID</li>
+   *   <li>Instrument Name</li>
+   *   <li>Number of calibratable sensors</li>
+   * </ol>
+   *
+   * @param conn A database connection
+   * @param stmt The query to be executed
+   * @return The list of instruments
+   * @throws DatabaseException If the query fails
+   */
+  private static List<InstrumentStub> runInstrumentListQuery(Connection conn, PreparedStatement stmt) throws DatabaseException {
+
+    ResultSet instruments = null;
+    List<InstrumentStub> instrumentList = new ArrayList<InstrumentStub>();
+    try {
       instruments = stmt.executeQuery();
       while (instruments.next()) {
         boolean hasCalibratableSensors = (instruments.getInt(3) > 0);
@@ -442,12 +540,11 @@ public class InstrumentDB {
       throw new DatabaseException("Error while retrieving instrument list", e);
     } finally {
       DatabaseUtils.closeResultSets(instruments);
-      DatabaseUtils.closeStatements(stmt);
-      DatabaseUtils.closeConnection(conn);
     }
 
     return instrumentList;
   }
+
 
   /**
    * Get an stub object for a specified instrument

--- a/WebApp/src/uk/ac/exeter/QuinCe/web/Instrument/CalibrationBean.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/web/Instrument/CalibrationBean.java
@@ -138,7 +138,9 @@ public abstract class CalibrationBean extends BaseManagedBean {
    * @return The navigation
    */
   public String addCalibration() {
-    String nav = getListNavigation();
+    // Null means we go back to the page we came from.
+    // Will be overridden if there's an error
+    String nav = null;
 
     try {
       if (getDbInstance().calibrationExists(getDataSource(), getEnteredCalibration())) {


### PR DESCRIPTION
There's no security beyond the fact that non-admin users don't get to see other peoples' instruments in the lists. If they manage to generate the right request they can still access other users' stuff. I'll add a separate issue for that eventuality.

I've removed the specific JOB MANAGER role, since a simple Admin user is sufficient for what we need right now.