### PR TITLE
(#929 and #127) Handling missing values

### DIFF
--- a/WebApp/src/uk/ac/exeter/QuinCe/EquilibratorPco2/EquilibratorPco2CalculationRecord.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/EquilibratorPco2/EquilibratorPco2CalculationRecord.java
@@ -3,6 +3,7 @@ package uk.ac.exeter.QuinCe.EquilibratorPco2;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import uk.ac.exeter.QuinCe.data.Calculation.CalculationDB;
 import uk.ac.exeter.QuinCe.data.Calculation.CalculationDBFactory;
@@ -66,5 +67,22 @@ public class EquilibratorPco2CalculationRecord extends CalculationRecord {
     columnAliases.put("pCO2 TE Wet", "pCO2 TE Wet");
     columnAliases.put("fCO2 TE", "fCO2 TE");
     columnAliases.put("fCO2", "fCO2");
+  }
+
+  @Override
+  public Map<String, Double> generateNullCalculationRecords() {
+
+    Map<String, Double> nullValues = new HashMap<String, Double>();
+
+    nullValues.put("delta_temperature", null);
+    nullValues.put("true_moisture", null);
+    nullValues.put("ph2o", null);
+    nullValues.put("dried_co2", null);
+    nullValues.put("calibrated_co2", null);
+    nullValues.put("pco2_te_wet", null);
+    nullValues.put("pco2_sst", null);
+    nullValues.put("fco2", null);
+
+    return nullValues;
   }
 }

--- a/WebApp/src/uk/ac/exeter/QuinCe/EquilibratorPco2/EquilibratorPco2Calculator.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/EquilibratorPco2/EquilibratorPco2Calculator.java
@@ -47,24 +47,45 @@ public class EquilibratorPco2Calculator extends DataReductionCalculator {
   public Map<String, Double> performDataReduction(DataSetRawDataRecord measurement) throws CalculatorException {
 
     LocalDateTime date = measurement.getDate();
-    double intakeTemperature = measurement.getSensorValue("Intake Temperature");
-    double salinity = measurement.getSensorValue("Salinity");
-    double equilibratorTemperature = measurement.getSensorValue("Equilibrator Temperature");
+    Double intakeTemperature = measurement.getSensorValue("Intake Temperature");
+    if (null == intakeTemperature) {
+      throw new CalculatorException("Intake Temperature missing");
+    }
+
+    Double salinity = measurement.getSensorValue("Salinity");
+    if (null == salinity) {
+      throw new CalculatorException("Salinity missing");
+    }
+
+    Double equilibratorTemperature = measurement.getSensorValue("Equilibrator Temperature");
+    if (null == equilibratorTemperature) {
+      throw new CalculatorException("Equilibrator Temperature missing");
+    }
 
     // TODO We need some kind of flag we can run to check which equilibrator pressure to use. #577
-    double equilibratorPressure;
+    Double equilibratorPressure = null;
 
     Double absoluteEquilibratorPressure = measurement.getSensorValue("Equilibrator Pressure (absolute)");
     if (null != absoluteEquilibratorPressure) {
       equilibratorPressure = absoluteEquilibratorPressure;
     } else {
-      double differential = measurement.getSensorValue("Equilibrator Pressure (differential)");
-      double atmospheric = measurement.getSensorValue("Ambient Pressure");
-      equilibratorPressure = atmospheric + differential;
+      Double differential = measurement.getSensorValue("Equilibrator Pressure (differential)");
+      Double atmospheric = measurement.getSensorValue("Ambient Pressure");
+      if (null != differential && null != atmospheric) {
+        equilibratorPressure = atmospheric + differential;
+      }
+    }
+
+    if (null == equilibratorPressure) {
+      throw new CalculatorException("Equilibrator Pressure missing");
     }
 
     Double xH2O = measurement.getSensorValue("xH2O");
-    double co2Measured = measurement.getSensorValue("CO2");
+
+    Double co2Measured = measurement.getSensorValue("CO2");
+    if (null == co2Measured) {
+      throw new CalculatorException("CO2 value missing");
+    }
 
     Double truexH2O = null;
     double co2Dried;

--- a/WebApp/src/uk/ac/exeter/QuinCe/EquilibratorPco2/EquilibratorPco2DB.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/EquilibratorPco2/EquilibratorPco2DB.java
@@ -4,7 +4,6 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Types;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -87,21 +86,15 @@ public class EquilibratorPco2DB extends CalculationDB {
     try {
       stmt = conn.prepareStatement(STORE_CALCULATION_VALUES_STATEMENT);
 
-      stmt.setDouble(1, values.get("delta_temperature"));
+      DatabaseUtils.setNullableValue(stmt, 1, values.get("delta_temperature"));
+      DatabaseUtils.setNullableValue(stmt, 2, values.get("true_moisture"));
+      DatabaseUtils.setNullableValue(stmt, 3, values.get("ph2o"));
+      DatabaseUtils.setNullableValue(stmt, 4, values.get("dried_co2"));
+      DatabaseUtils.setNullableValue(stmt, 5, values.get("calibrated_co2"));
+      DatabaseUtils.setNullableValue(stmt, 6, values.get("pco2_te_wet"));
+      DatabaseUtils.setNullableValue(stmt, 7, values.get("pco2_sst"));
+      DatabaseUtils.setNullableValue(stmt, 8, values.get("fco2"));
 
-      Double trueMoisture = values.get("true_moisture");
-      if (null == trueMoisture) {
-        stmt.setNull(2, Types.DOUBLE);
-      } else {
-        stmt.setDouble(2, trueMoisture);
-      }
-
-      stmt.setDouble(3, values.get("ph2o"));
-      stmt.setDouble(4, values.get("dried_co2"));
-      stmt.setDouble(5, values.get("calibrated_co2"));
-      stmt.setDouble(6, values.get("pco2_te_wet"));
-      stmt.setDouble(7, values.get("pco2_sst"));
-      stmt.setDouble(8, values.get("fco2"));
       stmt.setLong(9, measurementId);
 
       stmt.execute();
@@ -132,14 +125,14 @@ public class EquilibratorPco2DB extends CalculationDB {
         throw new RecordNotFoundException("Calculation data record not found", TABLE_NAME, record.getLineNumber());
       } else {
 
-        values.put("delta_temperature", dbRecord.getDouble(1));
-        values.put("true_moisture", dbRecord.getDouble(2));
-        values.put("ph2o", dbRecord.getDouble(3));
-        values.put("dried_co2", dbRecord.getDouble(4));
-        values.put("calibrated_co2", dbRecord.getDouble(5));
-        values.put("pco2_te_wet", dbRecord.getDouble(6));
-        values.put("pco2_sst", dbRecord.getDouble(7));
-        values.put("fco2", dbRecord.getDouble(8));
+        values.put("delta_temperature", DatabaseUtils.getNullableDouble(dbRecord, 1));
+        values.put("true_moisture", DatabaseUtils.getNullableDouble(dbRecord, 2));
+        values.put("ph2o", DatabaseUtils.getNullableDouble(dbRecord, 3));
+        values.put("dried_co2", DatabaseUtils.getNullableDouble(dbRecord, 4));
+        values.put("calibrated_co2", DatabaseUtils.getNullableDouble(dbRecord, 5));
+        values.put("pco2_te_wet", DatabaseUtils.getNullableDouble(dbRecord, 6));
+        values.put("pco2_sst", DatabaseUtils.getNullableDouble(dbRecord, 7));
+        values.put("fco2", DatabaseUtils.getNullableDouble(dbRecord, 8));
 
         for (int i = 1; i < record.getData().size(); i++) {
           DataColumn column = record.getData().get(i);

--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Calculation/CalculationRecord.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Calculation/CalculationRecord.java
@@ -361,6 +361,11 @@ public abstract class CalculationRecord extends DataRecord {
     super.addMessage(message);
     if (message.getFlag().moreSignificantThan(autoFlag)) {
       autoFlag = message.getFlag();
+
+      if (message.getFlag().equals(Flag.FATAL)) {
+        userFlag = autoFlag;
+        userMessage = message.getShortMessage();
+      }
     }
   }
 

--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Calculation/CalculationRecord.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Calculation/CalculationRecord.java
@@ -388,4 +388,9 @@ public abstract class CalculationRecord extends DataRecord {
    * Build the set of human readable/database column aliases
    */
   protected abstract void buildColumnAliases();
+
+  /**
+   * Set all calculated values to NULL
+   */
+  public abstract Map<String, Double> generateNullCalculationRecords();
 }

--- a/WebApp/src/uk/ac/exeter/QuinCe/jobs/files/AutoQCJob.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/jobs/files/AutoQCJob.java
@@ -295,7 +295,7 @@ public class AutoQCJob extends Job {
     for (long id : ids) {
       CalculationRecord record = CalculationRecordFactory.makeCalculationRecord(datasetId, id);
       record.loadData(conn);
-      if (!record.getUserFlag().equals(Flag.QUESTIONABLE) && !record.getUserFlag().equals(Flag.BAD) && !record.getUserFlag().equals(Flag.IGNORED)) {
+      if (!record.getAutoFlag().equals(Flag.FATAL) && !record.getUserFlag().equals(Flag.QUESTIONABLE) && !record.getUserFlag().equals(Flag.BAD) && !record.getUserFlag().equals(Flag.IGNORED)) {
         records.add(record);
       }
     }

--- a/WebApp/src/uk/ac/exeter/QuinCe/jobs/files/DataReductionJob.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/jobs/files/DataReductionJob.java
@@ -110,6 +110,7 @@ public class DataReductionJob extends Job {
           record.loadData(conn);
           record.addMessage(new MissingValueMessage(record.getLineNumber(), Message.NO_COLUMN_INDEX, e.getMessage(), Flag.FATAL));
           CalculationDBFactory.getCalculationDB().storeQC(conn, record);
+          calculationDB.storeCalculationValues(conn, measurement.getId(), record.generateNullCalculationRecords());
         }
       }
 

--- a/WebApp/src/uk/ac/exeter/QuinCe/utils/DatabaseUtils.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/utils/DatabaseUtils.java
@@ -5,6 +5,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Types;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.List;
@@ -309,6 +310,39 @@ public class DatabaseUtils {
     String result = null;
     if (null != fullName) {
       result = fullName.replaceAll(" ", "_").replaceAll("[\\(\\)]", "").toLowerCase();
+    }
+
+    return result;
+  }
+
+  /**
+   * Set a column value in a statement, handling null values as required
+   * @param stmt The statement
+   * @param column The column index
+   * @param value The value
+   * @throws SQLException If the value cannot be set
+   */
+  public static void setNullableValue(PreparedStatement stmt, int column, Double value) throws SQLException {
+    if (null == value) {
+      stmt.setNull(column, Types.DOUBLE);
+    } else {
+      stmt.setDouble(column, value);
+    }
+  }
+
+  /**
+   * Get a double value from a recordset, handling null values as null
+   * @param rs The recordset
+   * @param column The column index
+   * @return The column value
+   * @throws SQLException If the value cannot be retrieved
+   */
+  public static Double getNullableDouble(ResultSet rs, int column) throws SQLException {
+    Double result = null;
+
+    double value = rs.getDouble(column);
+    if (!rs.wasNull()) {
+      result = value;
     }
 
     return result;


### PR DESCRIPTION
Missing values as entered in the instrument definition screen are now set to `null` during data extraction.

The Calculator class will throw an exception due to missing values, which then sets the flag on the record to FATAL. For the time being, we assume that any exception during calculation will result in the FATAL flag being set. Assuming there's no bugs in the calculator that should be fine, but perhaps we shouldn't rely on it. The problem is that the calculator doesn't have access to set the flags itself, so this is the only way at the minute.

At the moment records with FATAL flags are shown strangely on plots (all the calculated values are zero). A new issue (#930) will take care of this by allowing the user to hide them.