### PR TITLE
(#936 & #935) Fix run type assignments

### DIFF
--- a/WebApp/src/uk/ac/exeter/QuinCe/web/Instrument/newInstrument/NewInstrumentBean.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/web/Instrument/newInstrument/NewInstrumentBean.java
@@ -1519,7 +1519,7 @@ public class NewInstrumentBean extends FileUploadBean {
     JSONArray json = new JSONArray();
 
     for (int i = 0; i < instrumentFiles.size(); i++) {
-      FileDefinition file = instrumentFiles.get(0);
+      FileDefinition file = instrumentFiles.get(i);
       if (file.getRunTypeColumn() != -1) {
         RunTypeAssignments assignments = file.getRunTypes();
 


### PR DESCRIPTION
Assigning run types when there were multiple files for the instruments had a couple of issues:

* Run types couldn't be set on the 2nd+ file
* Aliases couldn't be set on the first file

Both were caused by a stupid indexing issue.