### PR TITLE
(#944) File preview header is now brown

### DIFF
--- a/WebApp/WebContent/resources/style/newInstrument.css
+++ b/WebApp/WebContent/resources/style/newInstrument.css
@@ -78,7 +78,7 @@
 }
 
 .header {
-  color: #DD0000;
+  color: #AE7229;
 }
 
 .columnHeading {


### PR DESCRIPTION
Maren commented that files with large headers, when previewed, show a big block of red text when the file is uploaded, and her first thought was that an error had occurred when actually it's fine.

I've changed the colour from red to brown.

Before:
![red](https://user-images.githubusercontent.com/733650/45033097-cba28500-b053-11e8-96d6-0e9cd74c0e02.png)

After:
![brown](https://user-images.githubusercontent.com/733650/45033135-ef65cb00-b053-11e8-89ff-623ee2699dc8.png)
