### PR TITLE
(#968) Job errors are logged to the console

### DIFF
--- a/WebApp/src/uk/ac/exeter/QuinCe/jobs/JobManager.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/jobs/JobManager.java
@@ -575,6 +575,8 @@ public class JobManager {
       stmt.setString(2, StringUtils.stackTraceToString(error));
       stmt.setLong(3, jobID);
       stmt.execute();
+
+      System.out.println(StringUtils.stackTraceToString(error));
     } catch (SQLException e) {
       throw new DatabaseException("An error occurred while setting the error state of the job", e);
     } finally {


### PR DESCRIPTION
This is a quick and dirty fix that allows error notifications to be sent to the developers through the script that monitors the server log for exceptions. In the long run we need a proper notification system in QuinCe, but this will do the job for now.

Close #968