### PR TITLE
GitHub/976 Recursive Auto QC checks

### DIFF
--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Instrument/Calibration/ExternalStandardDB.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Instrument/Calibration/ExternalStandardDB.java
@@ -38,9 +38,11 @@ public class ExternalStandardDB extends CalibrationDB {
         + "c1.target, c1.deployment_date, c1.coefficients, c1.class "
       + "FROM calibration c1 INNER JOIN "
         + "(SELECT MAX(deployment_date) deployment_date, target "
-      + "FROM calibration WHERE deployment_date < ? GROUP BY target) "
-        + "AS c2 ON c1.target = c2.target AND c1.deployment_date = c2.deployment_date "
-        + "WHERE instrument_id = ? AND type = '" + EXTERNAL_STANDARD_CALIBRATION_TYPE + "'";
+      + "FROM calibration WHERE deployment_date < ? "
+      + "AND instrument_id = ? "
+      + "AND type = '" + EXTERNAL_STANDARD_CALIBRATION_TYPE + "' "
+      + "GROUP BY target) "
+      + "AS c2 ON c1.target = c2.target AND c1.deployment_date = c2.deployment_date";
 
   /**
    * The singleton instance of the class


### PR DESCRIPTION
*Depends on #982*

If a QC routine for outliers is only run once and flags a few points, any subsequent run will add more flags because the standard deviation threshold will have changed. The Auto QC job now runs each routine, takes out the flagged values, and runs it again until no more flags are added. This means the user sees all potential flags on the first round of QC and reduces the workload.

Depends on changes to the QC_Routines repository.

Before and after examples:
![screen shot 2018-10-18 at 12 30 20](https://user-images.githubusercontent.com/733650/47149789-eadc3580-d2d4-11e8-8183-00594cb44c20.png)
![screen shot 2018-10-18 at 12 52 57](https://user-images.githubusercontent.com/733650/47149794-f0398000-d2d4-11e8-8313-7aa3f1fa6740.png)
