### PR TITLE
(#984) Exact boundary matches on new datasets count as overlaps

### DIFF
--- a/WebApp/WebContent/resources/script/dataSets.js
+++ b/WebApp/WebContent/resources/script/dataSets.js
@@ -256,10 +256,10 @@ function setRangeFromClick(date, datasets) {
       }
       else {
         if (date < start && max > start) {
-          max = start
+          max = new Date(start.getTime() - 1000)
         }
         if (date > end && min < end) {
-          min = end
+          min = new Date(end.getTime() + 1000)
         }
       }
     }

--- a/WebApp/WebContent/resources/script/dataSets.js
+++ b/WebApp/WebContent/resources/script/dataSets.js
@@ -156,7 +156,7 @@ function dataSetOverlaps(newStart, newEnd) {
         var itemEnd = new Date(item['end']).getTime();
 
         var overlap = true;
-        if (itemEnd <= newStart || itemStart >= newEnd) {
+        if (itemEnd < newStart || itemStart > newEnd) {
           overlap = false;
         }
 

--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Instrument/Calibration/ExternalStandardDB.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Instrument/Calibration/ExternalStandardDB.java
@@ -38,9 +38,11 @@ public class ExternalStandardDB extends CalibrationDB {
         + "c1.target, c1.deployment_date, c1.coefficients, c1.class "
       + "FROM calibration c1 INNER JOIN "
         + "(SELECT MAX(deployment_date) deployment_date, target "
-      + "FROM calibration WHERE deployment_date < ? GROUP BY target) "
-        + "AS c2 ON c1.target = c2.target AND c1.deployment_date = c2.deployment_date "
-        + "WHERE instrument_id = ? AND type = '" + EXTERNAL_STANDARD_CALIBRATION_TYPE + "'";
+      + "FROM calibration WHERE deployment_date < ? "
+      + "AND instrument_id = ? "
+      + "AND type = '" + EXTERNAL_STANDARD_CALIBRATION_TYPE + "' "
+      + "GROUP BY target) "
+      + "AS c2 ON c1.target = c2.target AND c1.deployment_date = c2.deployment_date";
 
   /**
    * The singleton instance of the class


### PR DESCRIPTION
*Depends on #982*

Creating two datasets with exactly matching boundaries caused the end measurement to be used in both datasets. These changes ensure that there is always at least one second's gap between data sets to prevent this from happening.