### PR TITLE
(#1031) Data reduction/Auto QC performance improvements

### DIFF
--- a/WebApp/WebContent/job/job_list.xhtml
+++ b/WebApp/WebContent/job/job_list.xhtml
@@ -150,13 +150,17 @@
               <f:facet name="header">
                 Started
               </f:facet>
-              #{job.started}
+              <h:outputText value="#{job.started}">
+                <f:convertDateTime pattern="dd.MM.yyyy HH:mm:ss" />
+              </h:outputText>
             </p:column>
             <p:column>
               <f:facet name="header">
                 Ended
               </f:facet>
-              #{job.ended}
+              <h:outputText value="#{job.ended}">
+                <f:convertDateTime pattern="dd.MM.yyyy HH:mm:ss" />
+              </h:outputText>
             </p:column>
             <p:column>
               <f:facet name="header">

--- a/WebApp/WebContent/job/job_list.xhtml
+++ b/WebApp/WebContent/job/job_list.xhtml
@@ -131,7 +131,9 @@
               <f:facet name="header">
                 Submitted
               </f:facet>
-              #{job.created}
+              <h:outputText value="#{job.created}">
+                <f:convertDateTime pattern="dd.MM.yyyy HH:mm:ss" />
+              </h:outputText>
             </p:column>
             <p:column>
               <f:facet name="header">

--- a/WebApp/src/uk/ac/exeter/QuinCe/EquilibratorPco2/EquilibratorPco2DB.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/EquilibratorPco2/EquilibratorPco2DB.java
@@ -119,13 +119,12 @@ public class EquilibratorPco2DB extends CalculationDB {
 
   // TODO In the long run a lot of this can be factored out. Or it may become obsolete with per-field QC flags.
   @Override
-  public Map<String, Double> getCalculationValues(Connection conn, CalculationRecord record) throws MissingParamException, DatabaseException, RecordNotFoundException, NoSuchColumnException, MessageException {
+  public void loadCalculationValues(Connection conn, CalculationRecord record) throws MissingParamException, DatabaseException, RecordNotFoundException, NoSuchColumnException, MessageException {
     MissingParam.checkMissing(conn, "conn");
     MissingParam.checkMissing(record, "record");
 
     PreparedStatement stmt = null;
     ResultSet dbRecord = null;
-    Map<String, Double> values = null;
 
     try {
       stmt = conn.prepareStatement(GET_CALCULATION_VALUES_QUERY);
@@ -136,8 +135,7 @@ public class EquilibratorPco2DB extends CalculationDB {
       if (!dbRecord.next()) {
         throw new RecordNotFoundException("Calculation data record not found", TABLE_NAME, record.getLineNumber());
       } else {
-
-        values = loadCalculationValuesFromResultSet(record, dbRecord);
+        loadCalculationValuesFromResultSet(record, dbRecord);
       }
     } catch (SQLException|InvalidDataException|InvalidFlagException e) {
       throw new DatabaseException("Error retrieving calculations" , e);
@@ -145,8 +143,6 @@ public class EquilibratorPco2DB extends CalculationDB {
       DatabaseUtils.closeResultSets(dbRecord);
       DatabaseUtils.closeStatements(stmt);
     }
-
-    return values;
   }
 
   @Override
@@ -231,7 +227,7 @@ public class EquilibratorPco2DB extends CalculationDB {
    * @throws MessageException
    * @throws InvalidFlagException
    */
-  private Map<String, Double> loadCalculationValuesFromResultSet(CalculationRecord record,
+  private void loadCalculationValuesFromResultSet(CalculationRecord record,
       ResultSet dbRecord) throws SQLException, InvalidDataException, NoSuchColumnException,
       MessageException, InvalidFlagException {
 
@@ -259,7 +255,5 @@ public class EquilibratorPco2DB extends CalculationDB {
     record.setMessages(RebuildCode.getMessagesFromRebuildCodes(dbRecord.getString(11)));
     record.setUserFlag(new Flag(dbRecord.getInt(12)));
     record.setUserMessage(dbRecord.getString(13));
-
-    return values;
   }
 }

--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Calculation/CalculationDB.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Calculation/CalculationDB.java
@@ -293,7 +293,7 @@ public abstract class CalculationDB {
    * @throws MessageException If the automatic QC messages cannot be parsed
    * @throws NoSuchColumnException If the automatic QC messages cannot be parsed
    */
-  public Map<String, Double> getCalculationValues(DataSource dataSource, CalculationRecord record)
+  public void loadCalculationValues(DataSource dataSource, CalculationRecord record)
       throws MissingParamException, DatabaseException, RecordNotFoundException, NoSuchColumnException,
         MessageException {
     MissingParam.checkMissing(dataSource, "dataSource");
@@ -303,7 +303,7 @@ public abstract class CalculationDB {
 
     try {
       conn = dataSource.getConnection();
-      return getCalculationValues(conn, record);
+      loadCalculationValues(conn, record);
     } catch (SQLException e) {
       throw new DatabaseException("Error while getting calculation values", e);
     } finally {
@@ -322,7 +322,7 @@ public abstract class CalculationDB {
    * @throws MessageException If the automatic QC messages cannot be parsed
    * @throws NoSuchColumnException If the record structure does not match the application's configuration
    */
-  public abstract Map<String, Double> getCalculationValues(Connection conn, CalculationRecord record)
+  public abstract void loadCalculationValues(Connection conn, CalculationRecord record)
       throws MissingParamException, DatabaseException, RecordNotFoundException, NoSuchColumnException,
         MessageException;
 

--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Calculation/CalculationDB.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Calculation/CalculationDB.java
@@ -8,12 +8,14 @@ import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 import javax.sql.DataSource;
 
 import org.apache.commons.math3.stat.descriptive.rank.Percentile;
 import org.primefaces.json.JSONArray;
 
+import uk.ac.exeter.QCRoutines.data.InvalidDataException;
 import uk.ac.exeter.QCRoutines.data.NoSuchColumnException;
 import uk.ac.exeter.QCRoutines.messages.Flag;
 import uk.ac.exeter.QCRoutines.messages.InvalidFlagException;
@@ -53,7 +55,8 @@ public abstract class CalculationDB {
    * @throws DatabaseException If a database error occurs
    * @throws MissingParamException If any required parameters are missing
    */
-  public void createCalculationRecord(Connection conn, long measurementId) throws DatabaseException, MissingParamException {
+  public void createCalculationRecord(Connection conn, long measurementId)
+      throws DatabaseException, MissingParamException {
 
     MissingParam.checkMissing(conn, "conn");
     MissingParam.checkZeroPositive(measurementId, "measurementId");
@@ -105,7 +108,8 @@ public abstract class CalculationDB {
    * @throws MissingParamException If any required parameters are missing
    * @throws DatabaseException If a database error occurs
    */
-  public void deleteDatasetCalculationData(Connection conn, DataSet dataSet) throws MissingParamException, DatabaseException {
+  public void deleteDatasetCalculationData(Connection conn, DataSet dataSet)
+      throws MissingParamException, DatabaseException {
     MissingParam.checkMissing(conn, "conn");
     MissingParam.checkMissing(dataSet, "dataSet");
 
@@ -113,7 +117,8 @@ public abstract class CalculationDB {
 
     try {
       // TODO I think this could be done better. But maybe not.
-      String deleteStatement = "DELETE c.* FROM " + getCalculationTable() + " AS c INNER JOIN dataset_data AS d ON c.measurement_id = d.id WHERE d.dataset_id = ?";
+      String deleteStatement = "DELETE c.* FROM " + getCalculationTable()
+      + " AS c INNER JOIN dataset_data AS d ON c.measurement_id = d.id WHERE d.dataset_id = ?";
 
       stmt = conn.prepareStatement(deleteStatement);
       stmt.setLong(1, dataSet.getId());
@@ -136,7 +141,8 @@ public abstract class CalculationDB {
    * @throws RecordNotFoundException If the measurement does not exist
    * @throws InvalidFlagException The the flag value is invalid
    */
-  public Flag getAutoQCFlag(Connection conn, long measurementId) throws MissingParamException, DatabaseException, RecordNotFoundException, InvalidFlagException {
+  public Flag getAutoQCFlag(Connection conn, long measurementId)
+      throws MissingParamException, DatabaseException, RecordNotFoundException, InvalidFlagException {
 
     MissingParam.checkMissing(conn, "conn");
     MissingParam.checkZeroPositive(measurementId, "measurementId");
@@ -154,7 +160,8 @@ public abstract class CalculationDB {
 
       record = stmt.executeQuery();
       if (!record.next()) {
-        throw new RecordNotFoundException("Cannot find calculation record", getCalculationTable(), measurementId);
+        throw new RecordNotFoundException("Cannot find calculation record", getCalculationTable(),
+            measurementId);
       } else {
         result = new Flag(record.getInt(1));
       }
@@ -178,7 +185,8 @@ public abstract class CalculationDB {
    * @throws DatabaseException If a database error occurs
    * @throws RecordNotFoundException If the measurement cannot be found
    */
-  public List<Message> getQCMessages(Connection conn, long measurementId) throws MessageException, DatabaseException, RecordNotFoundException, MissingParamException {
+  public List<Message> getQCMessages(Connection conn, long measurementId)
+      throws MessageException, DatabaseException, RecordNotFoundException, MissingParamException {
 
     MissingParam.checkMissing(conn, "conn");
     MissingParam.checkZeroPositive(measurementId, "measurementId");
@@ -197,7 +205,8 @@ public abstract class CalculationDB {
       record = stmt.executeQuery();
 
       if (!record.next()) {
-        throw new RecordNotFoundException("Cannot find calculation record", getCalculationTable(), measurementId);
+        throw new RecordNotFoundException("Cannot find calculation record", getCalculationTable(),
+            measurementId);
       } else {
         result = RebuildCode.getMessagesFromRebuildCodes(record.getString(1));
       }
@@ -219,7 +228,8 @@ public abstract class CalculationDB {
    * @throws MissingParamException If any required parameters are missing
    * @throws DatabaseException If a database error occurs
    */
-  public void storeQC(Connection conn, CalculationRecord record) throws MissingParamException, DatabaseException, MessageException {
+  public void storeQC(Connection conn, CalculationRecord record)
+      throws MissingParamException, DatabaseException, MessageException {
 
     MissingParam.checkMissing(conn, "conn");
     MissingParam.checkMissing(record, "record");
@@ -269,7 +279,8 @@ public abstract class CalculationDB {
    * @throws MissingParamException If any required parameters are missing
    * @throws DatabaseException If a database error occurs
    */
-  public abstract void storeCalculationValues(Connection conn, long measurementId, Map<String, Double> values) throws MissingParamException, DatabaseException;
+  public abstract void storeCalculationValues(Connection conn, long measurementId, Map<String, Double> values)
+      throws MissingParamException, DatabaseException;
 
   /**
    * Add the calculation values to a {@link CalculationRecord}
@@ -282,7 +293,9 @@ public abstract class CalculationDB {
    * @throws MessageException If the automatic QC messages cannot be parsed
    * @throws NoSuchColumnException If the automatic QC messages cannot be parsed
    */
-  public Map<String, Double> getCalculationValues(DataSource dataSource, CalculationRecord record) throws MissingParamException, DatabaseException, RecordNotFoundException, NoSuchColumnException, MessageException {
+  public Map<String, Double> getCalculationValues(DataSource dataSource, CalculationRecord record)
+      throws MissingParamException, DatabaseException, RecordNotFoundException, NoSuchColumnException,
+        MessageException {
     MissingParam.checkMissing(dataSource, "dataSource");
     MissingParam.checkMissing(record, "record");
 
@@ -307,9 +320,11 @@ public abstract class CalculationDB {
    * @throws DatabaseException If a database error occurs
    * @throws RecordNotFoundException If the record does not exist
    * @throws MessageException If the automatic QC messages cannot be parsed
-   * @throws NoSuchColumnException If the automatic QC messages cannot be parsed
+   * @throws NoSuchColumnException If the record structure does not match the application's configuration
    */
-  public abstract Map<String, Double> getCalculationValues(Connection conn, CalculationRecord record) throws MissingParamException, DatabaseException, RecordNotFoundException, NoSuchColumnException, MessageException;
+  public abstract Map<String, Double> getCalculationValues(Connection conn, CalculationRecord record)
+      throws MissingParamException, DatabaseException, RecordNotFoundException, NoSuchColumnException,
+        MessageException;
 
   /**
    * Clear the calculation values for a given measurement. This method
@@ -319,7 +334,8 @@ public abstract class CalculationDB {
    * @throws MissingParamException If any required parameters are missing
    * @throws DatabaseException If a database error occurs
    */
-  public abstract void clearCalculationValues(Connection conn, long measurementId) throws MissingParamException, DatabaseException;
+  public abstract void clearCalculationValues(Connection conn, long measurementId)
+      throws MissingParamException, DatabaseException;
 
   /**
    * Get the list of column headings for calculation fields
@@ -344,7 +360,8 @@ public abstract class CalculationDB {
      * @throws DatabaseException If a database error occurs
      * @throws MissingParamException If any required parameters are missing
      */
-  public List<Long> getSelectableMeasurementIds(DataSource dataSource, long datasetId) throws MissingParamException, DatabaseException {
+  public List<Long> getSelectableMeasurementIds(DataSource dataSource, long datasetId)
+      throws MissingParamException, DatabaseException {
 
     MissingParam.checkMissing(dataSource, "dataSource");
     MissingParam.checkZeroPositive(datasetId, "datasetId");
@@ -395,7 +412,8 @@ public abstract class CalculationDB {
      * @throws MissingParamException If any required parameters are missing
      * @throws MessageException If the automatic QC messages cannot be extracted
    */
-  public void acceptAutoQc(DataSource dataSource, List<Long> rows) throws MissingParamException, DatabaseException, MessageException {
+  public void acceptAutoQc(DataSource dataSource, List<Long> rows)
+      throws MissingParamException, DatabaseException, MessageException {
     MissingParam.checkMissing(dataSource, "dataSource");
     MissingParam.checkMissing(rows, "rows", true);
 
@@ -474,7 +492,8 @@ public abstract class CalculationDB {
    * @throws MessageException If a QC message cannot be reconstructed from its rebuild code
    * @throws MissingParamException If any required parameters are missing
    */
-  public CommentSet getCommentsForRows(DataSource dataSource, List<Long> rows) throws DatabaseException, InvalidFlagException, MessageException, MissingParamException {
+  public CommentSet getCommentsForRows(DataSource dataSource, List<Long> rows)
+      throws DatabaseException, InvalidFlagException, MessageException, MissingParamException {
 
     MissingParam.checkMissing(dataSource, "dataSource");
     MissingParam.checkMissing(rows, "rows");
@@ -534,7 +553,8 @@ public abstract class CalculationDB {
      * @throws MissingParamException If any required parameters are missing
      * @throws InvalidFlagException If the flag value is invalid
    */
-  public void applyManualFlag(DataSource dataSource, List<Long> rows, int flag, String comment) throws DatabaseException, MissingParamException, InvalidFlagException {
+  public void applyManualFlag(DataSource dataSource, List<Long> rows, int flag, String comment)
+      throws DatabaseException, MissingParamException, InvalidFlagException {
 
     MissingParam.checkMissing(dataSource, "dataSource");
     MissingParam.checkMissing(rows, "rows");
@@ -583,7 +603,8 @@ public abstract class CalculationDB {
      * @throws DatabaseException If a database error occurs
      * @throws MissingParamException If any required parameters are missing
    */
-  public String getJsonData(DataSource dataSource, DataSet dataset, List<String> fields, String sortField) throws DatabaseException, MissingParamException, RecordNotFoundException, InstrumentException {
+  public String getJsonData(DataSource dataSource, DataSet dataset, List<String> fields, String sortField)
+      throws DatabaseException, MissingParamException, RecordNotFoundException, InstrumentException {
     return getJsonData(dataSource, dataset, fields, sortField, null, false);
   }
 
@@ -601,7 +622,9 @@ public abstract class CalculationDB {
    * @throws DatabaseException If a database error occurs
    * @throws MissingParamException If any required parameters are missing
    */
-  public String getJsonData(DataSource dataSource, DataSet dataset, List<String> fields, String sortField, List<Double> bounds, boolean limitPoints) throws DatabaseException, MissingParamException, RecordNotFoundException, InstrumentException {
+  public String getJsonData(DataSource dataSource, DataSet dataset, List<String> fields, String sortField,
+      List<Double> bounds, boolean limitPoints)
+          throws DatabaseException, MissingParamException, RecordNotFoundException, InstrumentException {
 
     MissingParam.checkMissing(dataSource, "dataSource");
     MissingParam.checkMissing(dataset, "dataset");
@@ -618,7 +641,8 @@ public abstract class CalculationDB {
       conn = dataSource.getConnection();
 
       List<String> datasetFields = DataSetDataDB.extractDatasetFields(conn, dataset, fields);
-      List<String> diagnosticFields = DiagnosticDataDB.extractDiagnosticFields(conn, dataset.getInstrumentId(), fields);
+      List<String> diagnosticFields = DiagnosticDataDB.extractDiagnosticFields(conn,
+          dataset.getInstrumentId(), fields);
       List<String> calculationFields = new ArrayList<String>(fields);
       calculationFields.removeAll(datasetFields);
       calculationFields.removeAll(diagnosticFields);
@@ -632,7 +656,8 @@ public abstract class CalculationDB {
         }
       }
 
-      Map<Long, Map<String, Double>> diagnosticData = DiagnosticDataDB.getDiagnosticValues(conn, dataset.getInstrumentId(), DataSetDataDB.getMeasurementIds(conn, dataset.getId()), diagnosticFields);
+      Map<Long, Map<String, Double>> diagnosticData =DiagnosticDataDB.getDiagnosticValues(conn,
+          dataset.getInstrumentId(), DataSetDataDB.getMeasurementIds(conn, dataset.getId()), diagnosticFields);
 
       StringBuilder sql = new StringBuilder();
 
@@ -746,7 +771,8 @@ public abstract class CalculationDB {
    * @throws RecordNotFoundException If the dataset does not exist
    * @throws InstrumentException If the instrument details cannot be retrieved
    */
-  public List<Double> getValueRange(DataSource dataSource, DataSet dataset, String field) throws DatabaseException, MissingParamException, RecordNotFoundException, InstrumentException {
+  public List<Double> getValueRange(DataSource dataSource, DataSet dataset, String field)
+      throws DatabaseException, MissingParamException, RecordNotFoundException, InstrumentException {
     MissingParam.checkMissing(dataSource, "dataSource");
     MissingParam.checkMissing(dataset, "dataset");
     MissingParam.checkMissing(field, "field");
@@ -786,7 +812,8 @@ public abstract class CalculationDB {
    * @throws RecordNotFoundException If the dataset does not exist
    * @throws InstrumentException If the instrument details cannot be retrieved
    */
-  private List<Double> getValueRange(Connection conn, DataSet dataset, String field, boolean filterFlags) throws DatabaseException, MissingParamException, RecordNotFoundException, InstrumentException {
+  private List<Double> getValueRange(Connection conn, DataSet dataset, String field, boolean filterFlags)
+      throws DatabaseException, MissingParamException, RecordNotFoundException, InstrumentException {
     PreparedStatement stmt = null;
     ResultSet results = null;
 
@@ -847,7 +874,8 @@ public abstract class CalculationDB {
    * @return The SQL statement
    * @throws SQLException If the statement cannot be constructed
    */
-  private PreparedStatement makeDiagnosticRangeStatement(Connection conn, long datasetId, long sensorId, boolean filterFlags) throws SQLException {
+  private PreparedStatement makeDiagnosticRangeStatement(Connection conn, long datasetId, long sensorId,
+      boolean filterFlags) throws SQLException {
 
     StringBuilder sql = new StringBuilder();
 
@@ -879,7 +907,8 @@ public abstract class CalculationDB {
    * @return The SQL statement
    * @throws SQLException If the statement cannot be constructed
    */
-  private PreparedStatement makeDatasetRangeStatement(Connection conn, long datasetId, String field, boolean filterFlags) throws SQLException {
+  private PreparedStatement makeDatasetRangeStatement(Connection conn, long datasetId, String field,
+      boolean filterFlags) throws SQLException {
 
     StringBuilder sql = new StringBuilder();
 
@@ -909,7 +938,8 @@ public abstract class CalculationDB {
    * @return The SQL statement
    * @throws SQLException If the statement cannot be constructed
    */
-  private PreparedStatement makeCalculationRangeStatement(Connection conn, long datasetId, String field, boolean filterFlags) throws SQLException {
+  private PreparedStatement makeCalculationRangeStatement(Connection conn, long datasetId, String field,
+      boolean filterFlags) throws SQLException {
 
     StringBuilder sql = new StringBuilder();
 
@@ -961,4 +991,20 @@ public abstract class CalculationDB {
       }
     }
   }
+
+  /**
+   * Load the calculation values into a set of records
+   * @param conn A database connection
+   * @param datasetId The ID of the dataset to which the records belong
+   * @param records The records to be populated
+   * @throws DatabaseException If a database error occurs
+   * @throws MissingParamException If any required parameters are missing
+   * @throws InvalidDataException If non-numeric values are found
+   * @throws NoSuchColumnException If the record structure does not match the application configuration
+   * @throws MessageException If the QC message cannot be parsed
+   * @throws InvalidFlagException If the QC flags are invalid
+   */
+  public abstract void loadCalculationValues(Connection conn, long datasetId,
+      TreeMap<Long, CalculationRecord> records) throws MissingParamException, DatabaseException,
+      InvalidDataException, NoSuchColumnException, MessageException, InvalidFlagException;
 }

--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Calculation/CalculationRecord.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Calculation/CalculationRecord.java
@@ -108,6 +108,8 @@ public abstract class CalculationRecord extends DataRecord {
   /**
    * The aliases of human-readable column headings to database column names
    */
+  // TODO Factor out so it's not copied in every instance of this class (can be per calculation type)
+  //      See issue #1033
   protected Map<String, String> columnAliases;
 
   /**
@@ -230,7 +232,15 @@ public abstract class CalculationRecord extends DataRecord {
   private void loadSensorData(Connection conn) throws MissingParamException, DatabaseException, RecordNotFoundException, InvalidDataException {
     dataSet = DataSetDB.getDataSet(conn, datasetId);
     DataSetRawDataRecord sensorData = DataSetDataDB.getMeasurement(conn, dataSet, lineNumber);
+    insertSensorData(sensorData);
+  }
 
+  /**
+   * Insert sensor data into the record
+   * @param sensorData The sensor data
+   * @throws InvalidDataException If any data type is invalid
+   */
+  public void insertSensorData(DataSetRawDataRecord sensorData) throws InvalidDataException {
     date = sensorData.getDate();
     longitude = sensorData.getLongitude();
     latitude = sensorData.getLatitude();
@@ -245,7 +255,6 @@ public abstract class CalculationRecord extends DataRecord {
       }
     }
   }
-
 
   /**
    * Load the calculation data for the measurement

--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Calculation/CalculationRecord.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Calculation/CalculationRecord.java
@@ -267,7 +267,7 @@ public abstract class CalculationRecord extends DataRecord {
    * @throws NoSuchColumnException If the automatic QC messages cannot be parsed
    */
   private void loadCalculationData(Connection conn) throws InvalidDataException, MissingParamException, DatabaseException, RecordNotFoundException, NoSuchColumnException, MessageException {
-    calculationDB.getCalculationValues(conn, this);
+    calculationDB.loadCalculationValues(conn, this);
   }
 
   /**

--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Calculation/DataReductionCalculator.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Calculation/DataReductionCalculator.java
@@ -2,6 +2,7 @@ package uk.ac.exeter.QuinCe.data.Calculation;
 
 import java.time.LocalDateTime;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.math3.stat.regression.SimpleRegression;
@@ -40,7 +41,7 @@ public abstract class DataReductionCalculator {
    * @throws CalculatorException If the set of calibration records is empty
    */
   protected DataReductionCalculator(CalibrationSet externalStandards, CalibrationDataSet calibrations) throws CalculatorException {
-    if (null == calibrations || calibrations.size() == 0) {
+    if (null == calibrations || !calibrations.hasData()) {
       throw new CalculatorException("No calibration records supplied to calculator");
     }
 
@@ -87,8 +88,9 @@ public abstract class DataReductionCalculator {
       for (String target : externalStandards.getTargets()) {
         double concentration = externalStandards.getCalibrationValue(target, sensorName);
         if (!ignoreZero || concentration > 0.0) {
-          DataSetRawDataRecord priorCalibration = calibrations.getCalibrationBefore(recordDate, target);
-          DataSetRawDataRecord postCalibration = calibrations.getCalibrationAfter(recordDate, target);
+          List<DataSetRawDataRecord> beforeAndAfter = calibrations.getSurroundingCalibrations(recordDate, target);
+          DataSetRawDataRecord priorCalibration = beforeAndAfter.get(0);
+          DataSetRawDataRecord postCalibration = beforeAndAfter.get(1);
           standardMeasurements.put(target, calculateStandardValueAtDate(recordDate, target, sensorName, priorCalibration, postCalibration));
         }
       }

--- a/WebApp/src/uk/ac/exeter/QuinCe/jobs/files/AutoQCJob.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/jobs/files/AutoQCJob.java
@@ -373,7 +373,7 @@ public class AutoQCJob extends Job {
     for (long id : ids) {
       CalculationRecord record = records.get(id);
       if (record.getUserFlag().equals(Flag.BAD) || record.getUserFlag().equals(Flag.QUESTIONABLE) ||
-          !record.getUserFlag().equals(Flag.GOOD)) {
+          record.getUserFlag().equals(Flag.GOOD)) {
 
         records.remove(id);
       }

--- a/WebApp/src/uk/ac/exeter/QuinCe/jobs/files/AutoQCJob.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/jobs/files/AutoQCJob.java
@@ -126,7 +126,6 @@ public class AutoQCJob extends Job {
    * @param thread The thread that is running this job
    * @see FileJob#FILE_ID_KEY
    */
-  @SuppressWarnings("unchecked")
   @Override
   protected void execute(JobThread thread) throws JobFailedException {
 
@@ -135,6 +134,7 @@ public class AutoQCJob extends Job {
     DataSet dataSet = null;
     try {
       conn = dataSource.getConnection();
+      conn.setAutoCommit(false);
       dataSet = DataSetDB.getDataSet(conn, datasetId);
       dataSet.setStatus(DataSet.STATUS_AUTO_QC);
       DataSetDB.updateDataSet(conn, dataSet);
@@ -170,8 +170,6 @@ public class AutoQCJob extends Job {
       }
 
       // Record the messages from the QC in the database
-      conn = dataSource.getConnection();
-      conn.setAutoCommit(false);
       for (DataRecord record : records) {
 
         if (thread.isInterrupted()) {

--- a/WebApp/src/uk/ac/exeter/QuinCe/jobs/files/DataReductionJob.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/jobs/files/DataReductionJob.java
@@ -75,6 +75,7 @@ public class DataReductionJob extends Job {
   protected void execute(JobThread thread) throws JobFailedException {
 
     Connection conn = null;
+    Connection statusConn = null;
     CalculationDB calculationDB = CalculationDBFactory.getCalculationDB();
     DataSet dataSet = null;
 
@@ -88,7 +89,10 @@ public class DataReductionJob extends Job {
       // Clear messages before executing job
       dataSet.clearMessages();
       dataSet.setStatus(DataSet.STATUS_DATA_REDUCTION);
-      DataSetDB.updateDataSet(dataSource.getConnection(), dataSet);
+
+      statusConn = dataSource.getConnection();
+      DataSetDB.updateDataSet(statusConn, dataSet);
+      statusConn.close();
 
       List<DataSetRawDataRecord> measurements = DataSetDataDB.getMeasurements(conn, dataSet);
       CalibrationDataSet calibrationRecords = CalibrationDataDB.getCalibrationRecords(conn, dataSet);
@@ -158,7 +162,7 @@ public class DataReductionJob extends Job {
 
       throw new JobFailedException(id, e);
     } finally {
-      DatabaseUtils.closeConnection(conn);
+      DatabaseUtils.closeConnection(conn, statusConn);
     }
   }
 

--- a/WebApp/src/uk/ac/exeter/QuinCe/utils/DatabaseUtils.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/utils/DatabaseUtils.java
@@ -85,15 +85,17 @@ public class DatabaseUtils {
    * All connections have their auto-commit flag set to true.
    * @param conn The database connection
    */
-  public static void closeConnection(Connection conn) {
-    if (null != conn) {
-      try {
-        if (!conn.getAutoCommit()) {
-          conn.rollback();
+  public static void closeConnection(Connection... conns) {
+    for (Connection conn : conns) {
+      if (null != conn) {
+        try {
+          if (!conn.getAutoCommit()) {
+            conn.rollback();
+          }
+          conn.close();
+        } catch (SQLException e) {
+          // Do nothing
         }
-        conn.close();
-      } catch (SQLException e) {
-        // Do nothing
       }
     }
   }

--- a/WebApp/src/uk/ac/exeter/QuinCe/web/datasets/ExportBean.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/web/datasets/ExportBean.java
@@ -263,8 +263,8 @@ public class ExportBean extends BaseManagedBean {
 
     List<CalculationRecord> calculationData = new ArrayList<CalculationRecord>(datasetData.size());
     for (DataSetRawDataRecord record : datasetData) {
-      CalculationRecord calcRecord = CalculationRecordFactory.makeCalculationRecord(dataset.getId(), record.getId());
-      CalculationDBFactory.getCalculationDB().getCalculationValues(conn, calcRecord);
+      CalculationRecord calcRecord = CalculationRecordFactory.makeCalculationRecord(getDatasetId(), record.getId());
+      CalculationDBFactory.getCalculationDB().loadCalculationValues(getDataSource(), calcRecord);
       calculationData.add(calcRecord);
     }
 

--- a/WebApp/src/uk/ac/exeter/QuinCe/web/datasets/ManualQcBean.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/web/datasets/ManualQcBean.java
@@ -181,7 +181,7 @@ public class ManualQcBean extends PlotPageBean {
     for (DataSetRawDataRecord record : datasetData) {
       measurementIds.add(record.getId());
       CalculationRecord calcRecord = CalculationRecordFactory.makeCalculationRecord(getDatasetId(), record.getId());
-      CalculationDBFactory.getCalculationDB().getCalculationValues(getDataSource(), calcRecord);
+      CalculationDBFactory.getCalculationDB().loadCalculationValues(getDataSource(), calcRecord);
       calculationData.add(calcRecord);
     }
 


### PR DESCRIPTION
Data reduction was slow (7 minutes on the example data set) because it searched the database for external standards records for each measurement. The records are now all loaded into memory (time reduced to 40 seconds), and searching for the required records has a cache implemented to improve performance further (20 seconds).

The Auto QC job read each record from the database in a separate SQL statement before processing (17 minutes on the example data set). This was reduced to a single SQL call (job time reduced to 3 seconds).