### PR TITLE
(#1030) Y axis buttons now have correct label

### DIFF
--- a/WebApp/WebContent/WEB-INF/templates/plot_page.xhtml
+++ b/WebApp/WebContent/WEB-INF/templates/plot_page.xhtml
@@ -113,7 +113,7 @@
                         <p:selectBooleanButton widgetVar="xAxis-#{variable.id}" onLabel="X" offLabel="X" styleClass="axisButton" id="xAxisButton" onchange="updateXAxisButtons(#{variable.id})"/>
                       </ui:fragment>
                       <ui:fragment rendered="#{variable.canUseOnYAxis}">
-                        <p:selectBooleanButton widgetVar="yAxis-#{variable.id}" onLable="Y" offLabel="Y" styleClass="axisButton" id="yAxisButton" onchange="updateYAxisButtons(#{variable.id})"/>
+                        <p:selectBooleanButton widgetVar="yAxis-#{variable.id}" onLabel="Y" offLabel="Y" styleClass="axisButton" id="yAxisButton" onchange="updateYAxisButtons(#{variable.id})"/>
                       </ui:fragment>
                     </div>
                   </div>


### PR DESCRIPTION
See screenshot in #1030. This has been fixed. The problem was that the attribute for the label was misspelled.

Close #1030 