### PR TITLE
(#1013) Custom headings on exports

### DIFF
--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Export/ExportConfig.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Export/ExportConfig.java
@@ -25,18 +25,24 @@ import uk.ac.exeter.QuinCe.web.system.ResourceManager;
  *     <b>exportName</b> - The display name of this export option.
  *   </li>
  *   <li>
- *     <b>Separator</b> - The column separator in the exported file. This must be a string, either
+ *     <b>separator</b> - The column separator in the exported file. This must be a string, either
  *      'comma' or 'tab'.
  *   </li>
  *   <li>
- *     <b>Flags</b> - The flag values to be included in the export, as numeric values.
+ *     <b>flags</b> - The flag values to be included in the export, as numeric values.
  *   </li>
  *   <li>
- *     <b>Sensors</b> - The names of the sensor columns to be included in the output
+ *     <b>sensors</b> - The names of the sensor columns to be included in the output
+ *   </li>
+ *   <li>
+ *     <b>sensors_titles</b> - The column headers to use for the sensors
  *   </li>
  *   <li>
  *     <b>[Calculation Name]</b> - For each available calculation path, Any calculated value
  *     can be included.
+ *   </li>
+ *   <li>
+ *     <b>[Calculation Name]_titles</b> - The headers to use for the calculation columns
  *   </li>
  * </ul>
  *

--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Export/ExportOption.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Export/ExportOption.java
@@ -213,7 +213,8 @@ public class ExportOption {
           try {
             calculationDb = CalculationDBFactory.getCalculationDB(key.substring(0, key.length() - 8));
           } catch (CalculatorException e) {
-            throw new ExportConfigurationException(index, "Unrecognised calculation idendtifier '" + calculationIdentifier + "'");
+            throw new ExportConfigurationException(index, "Unrecognised calculation idendtifier '"
+                + calculationIdentifier + "'");
           }
 
           try {

--- a/WebApp/src/uk/ac/exeter/QuinCe/web/datasets/ExportBean.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/web/datasets/ExportBean.java
@@ -278,15 +278,15 @@ public class ExportBean extends BaseManagedBean {
     output.append("Latitude");
     output.append(exportOption.getSeparator());
 
-    for (String sensorColumn : exportOption.getSensorColumns()) {
-      output.append(sensorColumn);
+    for (String sensorColumnHeading : exportOption.getSensorColumnHeadings()) {
+      output.append(sensorColumnHeading);
       output.append(exportOption.getSeparator());
     }
 
     // TODO Replace when mutiple calculation paths are in place
-    List<String> calculationColumns = exportOption.getCalculationColumns("equilibrator_pco2");
-    for (int i = 0; i < calculationColumns.size(); i++) {
-      output.append(calculationColumns.get(i));
+    List<String> calculationColumnHeadings = exportOption.getCalculationColumnHeadings("equilibrator_pco2");
+    for (int i = 0; i < calculationColumnHeadings.size(); i++) {
+      output.append(calculationColumnHeadings.get(i));
       output.append(exportOption.getSeparator());
     }
 

--- a/WebApp/src/uk/ac/exeter/QuinCe/web/datasets/ExportBean.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/web/datasets/ExportBean.java
@@ -285,9 +285,11 @@ public class ExportBean extends BaseManagedBean {
 
     // TODO Replace when mutiple calculation paths are in place
     List<String> calculationColumnHeadings = exportOption.getCalculationColumnHeadings("equilibrator_pco2");
-    for (int i = 0; i < calculationColumnHeadings.size(); i++) {
-      output.append(calculationColumnHeadings.get(i));
-      output.append(exportOption.getSeparator());
+    if (null != calculationColumnHeadings) {
+      for (int i = 0; i < calculationColumnHeadings.size(); i++) {
+        output.append(calculationColumnHeadings.get(i));
+        output.append(exportOption.getSeparator());
+      }
     }
 
     output.append("QC Flag");
@@ -346,15 +348,18 @@ public class ExportBean extends BaseManagedBean {
           output.append(exportOption.getSeparator());
         }
 
-        for (String calculatedColumn : exportOption.getCalculationColumns("equilibrator_pco2")) {
-          Double value = calculationRecord.getNumericValue(calculatedColumn);
-          if (null == value) {
-            output.append("NaN");
-          } else {
-            output.append(numberFormatter.format(value));
-          }
+        List<String> calculationColumns = exportOption.getCalculationColumns("equilibrator_pco2");
+        if (null != calculationColumns) {
+          for (String calculatedColumn : calculationColumns) {
+            Double value = calculationRecord.getNumericValue(calculatedColumn);
+            if (null == value) {
+              output.append("NaN");
+            } else {
+              output.append(numberFormatter.format(value));
+            }
 
-          output.append(exportOption.getSeparator());
+            output.append(exportOption.getSeparator());
+          }
         }
 
         if (dataset.isNrt()) {

--- a/configuration/export_config.json
+++ b/configuration/export_config.json
@@ -15,15 +15,15 @@
     "sensors": ["Intake Temperature", "Salinity", "Equilibrator Temperature", "Equilibrator Pressure", "xH2O", "CO2"],
     "sensors_headings": ["Intake Temperature", "Salinity", "Equilibrator Temperature", "Equilibrator Pressure", "xH2O", "xCO2water_equ_dry"],
     "equilibrator_pco2_columns": ["pCO2 TE Wet", "pCO2 SST", "fCO2"],
-    "equilibrator_pco2_headings": ["pCO2water_equ_wet", "pCO2water_sst_wet", "fCO2water_sst_wet"],
+    "equilibrator_pco2_headings": ["pCO2water_equ_wet", "pCO2water_sst_wet", "fCO2water_sst_wet"]
   },
   {
     "exportName": "SST+Salinity QC",
     "separator": "comma",
     "flags": [2,3,4],
     "sensors": ["Intake Temperature", "Salinity"],
-    "sensors_headings": ["Intake Temperature", "Salinity"]
-    "equilibrator_pco2": []
+    "sensors_headings": ["Intake Temperature", "Salinity"],
+    "equilibrator_pco2": [],
     "equilibrator_pco2_headings": []
   }
 ]

--- a/configuration/export_config.json
+++ b/configuration/export_config.json
@@ -13,9 +13,9 @@
   	"separator": "comma",
   	"flags": [2],
     "sensors": ["Intake Temperature", "Salinity", "Equilibrator Temperature", "Equilibrator Pressure", "xH2O", "CO2"],
-    "sensors_headings": ["Intake Temperature", "Salinity", "Equilibrator Temperature", "Equilibrator Pressure", "xH2O", "xCO2water_equ_dry"],
+    "sensors_headings": ["Temp", "P_sal", "Temp_in_eq", "Press_eq", "xH2OEquilSamp", "xCO2_dryWater"],
     "equilibrator_pco2_columns": ["pCO2 TE Wet", "pCO2 SST", "fCO2"],
-    "equilibrator_pco2_headings": ["pCO2water_equ_wet", "pCO2water_sst_wet", "fCO2water_sst_wet"]
+    "equilibrator_pco2_headings": ["pCO2_eqT", "pCO2", "fCO2"]
   },
   {
     "exportName": "SST+Salinity QC",

--- a/configuration/export_config.json
+++ b/configuration/export_config.json
@@ -3,21 +3,27 @@
   	"exportName": "SOCAT",
   	"separator": "tab",
   	"flags": [2, 3, 4],
-  	"sensors": ["Intake Temperature", "Salinity", "Equilibrator Temperature", "Equilibrator Pressure", "xH2O", "CO2"],
-  	"equilibrator_pco2": ["Delta T", "fCO2"]
+    "sensors": ["Intake Temperature", "Salinity", "Equilibrator Temperature", "Equilibrator Pressure", "xH2O", "CO2"],
+    "sensors_headings": ["Intake Temperature", "Salinity", "Equilibrator Temperature", "Equilibrator Pressure", "xH2O", "CO2"],
+    "equilibrator_pco2_columns": ["Delta T", "fCO2"],
+    "equilibrator_pco2_headings": ["Delta T", "fCO2"]
   },
   {
-    "exportName": "ICOS OTC",
-    "separator": "comma",
-    "flags": [2],
+  	"exportName": "ICOS OTC",
+  	"separator": "comma",
+  	"flags": [2],
     "sensors": ["Intake Temperature", "Salinity", "Equilibrator Temperature", "Equilibrator Pressure", "xH2O", "CO2"],
-    "equilibrator_pco2": ["Delta T", "pH2O", "fCO2"]
+    "sensors_headings": ["Intake Temperature", "Salinity", "Equilibrator Temperature", "Equilibrator Pressure", "xH2O", "xCO2water_equ_dry"],
+    "equilibrator_pco2_columns": ["pCO2 TE Wet", "pCO2 SST", "fCO2"],
+    "equilibrator_pco2_headings": ["pCO2water_equ_wet", "pCO2water_sst_wet", "fCO2water_sst_wet"],
   },
   {
     "exportName": "SST+Salinity QC",
     "separator": "comma",
     "flags": [2,3,4],
     "sensors": ["Intake Temperature", "Salinity"],
+    "sensors_headings": ["Intake Temperature", "Salinity"]
     "equilibrator_pco2": []
+    "equilibrator_pco2_headings": []
   }
 ]

--- a/configuration/export_config.json
+++ b/configuration/export_config.json
@@ -23,7 +23,7 @@
     "flags": [2,3,4],
     "sensors": ["Intake Temperature", "Salinity"],
     "sensors_headings": ["Intake Temperature", "Salinity"],
-    "equilibrator_pco2": [],
+    "equilibrator_pco2_columns": [],
     "equilibrator_pco2_headings": []
   }
 ]


### PR DESCRIPTION
This change allows us to specify what the headings should be in exported files instead of using the internal names. Required by some data destinations that use fixed vocabularies.