### PR TITLE
(#1060) Dataset status set correctly after Auto QC

### DIFF
--- a/WebApp/src/uk/ac/exeter/QuinCe/jobs/files/AutoQCJob.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/jobs/files/AutoQCJob.java
@@ -126,7 +126,6 @@ public class AutoQCJob extends Job {
    * @param thread The thread that is running this job
    * @see FileJob#FILE_ID_KEY
    */
-  @SuppressWarnings("unchecked")
   @Override
   protected void execute(JobThread thread) throws JobFailedException {
 
@@ -242,9 +241,9 @@ public class AutoQCJob extends Job {
 
         if (writeRecord) {
           calculationDB.storeQC(conn, (CalculationRecord) record);
-          if (qcRecord.getUserFlag().equals(Flag.NEEDED)) {
-            userQcNeeded = true;
-          }
+        }
+        if (qcRecord.getUserFlag().equals(Flag.NEEDED)) {
+          userQcNeeded = true;
         }
       }
 

--- a/WebApp/src/uk/ac/exeter/QuinCe/jobs/files/AutoQCJob.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/jobs/files/AutoQCJob.java
@@ -138,6 +138,7 @@ public class AutoQCJob extends Job {
       dataSet = DataSetDB.getDataSet(conn, datasetId);
       dataSet.setStatus(DataSet.STATUS_AUTO_QC);
       DataSetDB.updateDataSet(conn, dataSet);
+      boolean userQcNeeded = false;
 
       CalculationDB calculationDB = CalculationDBFactory.getCalculationDB();
 
@@ -241,6 +242,9 @@ public class AutoQCJob extends Job {
 
         if (writeRecord) {
           calculationDB.storeQC(conn, (CalculationRecord) record);
+          if (qcRecord.getUserFlag().equals(Flag.NEEDED)) {
+            userQcNeeded = true;
+          }
         }
       }
 
@@ -253,8 +257,9 @@ public class AutoQCJob extends Job {
           if (dataSet.isNrt()) {
             dataSet.setStatus(DataSet.STATUS_READY_FOR_EXPORT);
           } else {
-            dataSet.setStatus(DataSet.STATUS_USER_QC);
-            if (dataSet.getNeedsFlagCount() == 0) {
+            if (userQcNeeded) {
+              dataSet.setStatus(DataSet.STATUS_USER_QC);
+            } else {
               dataSet.setStatus(DataSet.STATUS_READY_FOR_SUBMISSION);
             }
           }


### PR DESCRIPTION
The previous set status logic looked at the `neededFlag` count in the `DataSet` object, but that is not updated during the automatic QC. In general use there's no legitimate reason to have a setter method on this property, so I've added a flag to the Auto QC job that tracks whether a Needs Flag is set, and uses that to determine what the final status should be set to.