### PR TITLE
(#1081) Nans stored as null

### DIFF
--- a/WebApp/src/uk/ac/exeter/QuinCe/utils/DatabaseUtils.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/utils/DatabaseUtils.java
@@ -325,7 +325,7 @@ public class DatabaseUtils {
    * @throws SQLException If the value cannot be set
    */
   public static void setNullableValue(PreparedStatement stmt, int column, Double value) throws SQLException {
-    if (null == value) {
+    if (null == value || value.isNaN()) {
       stmt.setNull(column, Types.DOUBLE);
     } else {
       stmt.setDouble(column, value);


### PR DESCRIPTION
Pretty much does what it says - correctly detects NaN values and converts them to null when storing in the database.