### PR TITLE
(#1080) Prevent pre/post flush skipping routines from falling off the end of the file

### DIFF
--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Dataset/DataSetRawData.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Dataset/DataSetRawData.java
@@ -612,18 +612,22 @@ public abstract class DataSetRawData {
       LocalDateTime lastTime = getLine(fileIndex, lineIndex).getDate();
 
       lineIndex.increment();
-      LocalDateTime currentTime = getLine(fileIndex, lineIndex).getDate();
-      while (DateTimeUtils.secondsBetween(lastTime, currentTime) < instrument.getPreFlushingTime()) {
-        lineIndex.increment();
-        if (lineIndex.greaterThanOrEqualTo(getFileSize(fileIndex))) {
-          lineIndex.setValue(EOF.getValue());
-          break;
-        } else {
-          DataFileLine newLine = getLine(fileIndex, lineIndex);
-          currentTime = newLine.getDate();
-          if (!newLine.getRunType().equals(runType)) {
-            withinRunType = false;
+      if (lineIndex.greaterThanOrEqualTo(getFileSize(fileIndex))) {
+        lineIndex.setValue(EOF.getValue());
+      } else {
+        LocalDateTime currentTime = getLine(fileIndex, lineIndex).getDate();
+        while (DateTimeUtils.secondsBetween(lastTime, currentTime) < instrument.getPreFlushingTime()) {
+          lineIndex.increment();
+          if (lineIndex.greaterThanOrEqualTo(getFileSize(fileIndex))) {
+            lineIndex.setValue(EOF.getValue());
             break;
+          } else {
+            DataFileLine newLine = getLine(fileIndex, lineIndex);
+            currentTime = newLine.getDate();
+            if (!newLine.getRunType().equals(runType)) {
+              withinRunType = false;
+              break;
+            }
           }
         }
       }

--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Dataset/DataSetRawData.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Dataset/DataSetRawData.java
@@ -514,7 +514,7 @@ public abstract class DataSetRawData {
               } else {
                 while (getLine(fileIndex, nextLineIndex).isIgnored()) {
                   nextLineIndex.increment();
-                  if (nextLineIndex.greaterThan(getFileSize(fileIndex))) {
+                  if (nextLineIndex.greaterThanOrEqualTo(getFileSize(fileIndex))) {
                     result = EOF;
                     finished = true;
                     preFlushingTimeProcessed = true;
@@ -558,7 +558,7 @@ public abstract class DataSetRawData {
       while (!finished) {
 
         int nextLineIndex = previousLineIndex + 1;
-        if (nextLineIndex > getFileSize(fileIndex)) {
+        if (nextLineIndex >= getFileSize(fileIndex)) {
           inPostFlushing = (DateTimeUtils.secondsBetween(lineDate, previousDate) <= instrument.getPostFlushingTime());
           finished = true;
         } else {
@@ -615,7 +615,7 @@ public abstract class DataSetRawData {
       LocalDateTime currentTime = getLine(fileIndex, lineIndex).getDate();
       while (DateTimeUtils.secondsBetween(lastTime, currentTime) < instrument.getPreFlushingTime()) {
         lineIndex.increment();
-        if (lineIndex.greaterThan(getFileSize(fileIndex))) {
+        if (lineIndex.greaterThanOrEqualTo(getFileSize(fileIndex))) {
           lineIndex.setValue(EOF.getValue());
           break;
         } else {

--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Dataset/DataSetRawData.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Dataset/DataSetRawData.java
@@ -447,7 +447,7 @@ public abstract class DataSetRawData {
         result = new ExtendedMutableInt(0);
       } else {
         result = currentLineIndex.incrementedClone();
-        if (result.greaterThan(fileLastLine)) {
+        if (result.greaterThanOrEqualTo(fileLastLine)) {
           result = EOF;
         }
       }
@@ -467,7 +467,7 @@ public abstract class DataSetRawData {
         nextLineIndex = currentLineIndex.incrementedClone();
       }
 
-      if (nextLineIndex.greaterThan(fileLastLine)) {
+      if (nextLineIndex.greaterThanOrEqualTo(fileLastLine)) {
         result = EOF;
         finished = true;
       } else {
@@ -493,7 +493,7 @@ public abstract class DataSetRawData {
           // We're in a new Run Type. Skip any Ignored lines
           while (!finished && getLine(fileIndex, nextLineIndex).isIgnored()) {
             nextLineIndex.increment();
-            if (nextLineIndex.greaterThan(fileLastLine)) {
+            if (nextLineIndex.greaterThanOrEqualTo(fileLastLine)) {
               result = EOF;
               finished = true;
             }

--- a/WebApp/src/uk/ac/exeter/QuinCe/utils/ExtendedMutableInt.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/utils/ExtendedMutableInt.java
@@ -33,6 +33,15 @@ public class ExtendedMutableInt extends MutableInt {
   }
 
   /**
+   * See if the value of this object is greater than or equal to the specified value
+   * @param otherValue The value to compare
+   * @return {@code this >= otherValue}
+   */
+  public boolean greaterThanOrEqualTo(int otherValue) {
+    return (getValue() >= otherValue);
+  }
+
+  /**
    * Create a new {@code ExtendedMutableInt} object with
    * a value one higher than this object's value.
    * @return The new object


### PR DESCRIPTION
The end-of-file check in the flushing time skip routines used `> file size` as its EOF detector. Since the line numbers are zero-based, this should have been `>=`

I have a test file from a user that's 15Mb (couldn't be bothered to shrink it down to an isolated test case) - I can supply it if needed.

Close #1080 