### PR TITLE
(#1087) Fix SQL query for finding diagnostic sensors

### DIFF
--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Dataset/DiagnosticDataDB.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Dataset/DiagnosticDataDB.java
@@ -43,7 +43,7 @@ public class DiagnosticDataDB {
       + "id, sensor_type, sensor_name FROM file_column "
       + "WHERE sensor_type LIKE 'Diagnostic: %' AND "
       + "file_definition_id IN "
-      + "(SELECT file_definition_id FROM file_definition WHERE instrument_id = ?) "
+      + "(SELECT id FROM file_definition WHERE instrument_id = ?) "
       + "ORDER BY sensor_type, sensor_name";
 
   /**


### PR DESCRIPTION
The SQL for finding diagnostic sensors was broken, and ended up just returning any random diagnostic sensor it could from the database. This then fell apart when the QC table was built, because the list of diagnostic sensors didn't match the actual data for the instrument.

I have no idea why the SQL statement worked, but we'll worry about that another time.
