### PR TITLE
(#993) Automagically add quince version to quince.properties

### DIFF
--- a/configuration/quince.properties
+++ b/configuration/quince.properties
@@ -16,5 +16,5 @@ sensors.configfile=%quince_root_folder%/configuration/sensor_config.csv
 runtypes.configfile=%quince_root_folder%/configuration/run_types_config.csv
 map.max_points=1000
 diagnostic_sensors=Temperature,Pressure,Air Flow,Water Flow,Voltage
-version=1.0.2
+version=%quince_version%
 

--- a/scripts/setup_replace_strings.sh
+++ b/scripts/setup_replace_strings.sh
@@ -35,11 +35,21 @@ fi
 
 # First get only default file
 setup=$(cat quince.setup.default)
+
+
 setupfile="quince.setup$setuptype"
 if [ -e $setupfile ]
 then
   # using awk to keep properties in quince.setup.default not in quince.setup
   setup=$(awk -F= '!a[$1]++' $setupfile quince.setup.default)
+fi
+
+# If %quince_version% don't exist, append quince version from current git tag
+git_tag=$(git describe --tag --abbrev=0)
+if [ -z $(echo "$setup" | grep -e '^%quince_version%') ]
+then
+  setup="$setup
+  %quince_version%=$git_tag"
 fi
 
 


### PR DESCRIPTION
run setup_reverse_strings.sh and then setup_replace_strings.sh for this change to take effect the first time.

This should add the current git tag as a version number to quince.properties when `./scripts/setup_replace_strings.sh` is run. If %quince_version% is set in quince.setup.default or another quince setup file, this will override the functionality.