### PR TITLE
(#1086) Prevent login errors executing internalError(e)

### DIFF
--- a/WebApp/src/uk/ac/exeter/QuinCe/web/User/LoginBean.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/web/User/LoginBean.java
@@ -121,7 +121,7 @@ public class LoginBean extends BaseManagedBean {
       User user = UserDB.getUser(getDataSource(), emailAddress);
       int authenticateResult;
 
-      if (user.isApiUser()) {
+      if (null != user && user.isApiUser()) {
         // API users are not allowed to log in
         authenticateResult = UserDB.AUTHENTICATE_FAILED;
       } else {


### PR DESCRIPTION
Introduction of the new Api introduced was accessing an object that might not be initialised.

close #1085
close #1086 