### PR TITLE
(#1052) Show only auto QC for NRT data sets.

### DIFF
--- a/WebApp/src/uk/ac/exeter/QuinCe/web/Plot.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/web/Plot.java
@@ -308,7 +308,12 @@ public class Plot {
       // TODO Remove the magic strings. Make PSF fields in CalculationDB
       fields.add(xAxis.getFieldName());
       fields.add("id");
-      fields.add("user_flag");
+      if (parentBean.getDataset().isNrt()) {
+        fields.add("auto_flag");
+      } else {
+        fields.add("user_flag");
+      }
+
 
       if (null != yAxis) {
         for (Variable variable : yAxis) {
@@ -324,7 +329,11 @@ public class Plot {
       fields.add("latitude");
       fields.add("date");
       fields.add("id");
-      fields.add("user_flag");
+      if (parentBean.getDataset().isNrt()) {
+        fields.add("auto_flag");
+      } else {
+        fields.add("user_flag");
+      }
       fields.add(mapVariable.getFieldName());
     }
     }

--- a/WebApp/src/uk/ac/exeter/QuinCe/web/datasets/ManualQcBean.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/web/datasets/ManualQcBean.java
@@ -132,12 +132,18 @@ public class ManualQcBean extends PlotPageBean {
 
     headings.put("Automatic QC");
     headings.put("Automatic QC Message");
-    headings.put("Manual QC");
-    headings.put("Manual QC Message");
 
     // Columns are zero-based, so we don't need to add one to get to the auto flag column
     autoFlagColumn = dataHeadings.size() + calculationHeadings.size() + diagnosticHeadings.size();
-    userFlagColumn = autoFlagColumn + 2;
+
+    if (!getDataset().isNrt()) {
+      headings.put("Manual QC");
+      headings.put("Manual QC Message");
+      userFlagColumn = autoFlagColumn + 2;
+    } else {
+      userFlagColumn = -1;
+    }
+
 
     return headings.toString();
   }
@@ -258,14 +264,16 @@ public class ManualQcBean extends PlotPageBean {
         obj.put(String.valueOf(columnIndex), calcData.getAutoQCMessagesString());
       }
 
-      columnIndex++;
-      obj.put(String.valueOf(columnIndex), calcData.getUserFlag().getFlagValue());
+      if (!getDataset().isNrt()) {
+        columnIndex++;
+        obj.put(String.valueOf(columnIndex), calcData.getUserFlag().getFlagValue());
 
-      columnIndex++;
-      if (null == calcData.getUserMessage()) {
-        obj.put(String.valueOf(columnIndex), JSONObject.NULL);
-      } else {
-        obj.put(String.valueOf(columnIndex), calcData.getUserMessage());
+        columnIndex++;
+        if (null == calcData.getUserMessage()) {
+          obj.put(String.valueOf(columnIndex), JSONObject.NULL);
+        } else {
+          obj.put(String.valueOf(columnIndex), calcData.getUserMessage());
+        }
       }
 
       json.put(obj);


### PR DESCRIPTION
In plots, highlight points with Auto QC flags instead of user QC flags (which can't be set)
In the table, hide the User QC column

To test, view an NRT data set vs a normal one to see the differences.