### PR TITLE
(#1133) Changes to ICOS OTC export format

### DIFF
--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Dataset/DataSetDB.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Dataset/DataSetDB.java
@@ -667,8 +667,8 @@ public class DataSetDB {
 
     JSONObject result = new JSONObject();
     result.put("name", dataset.getName());
-    result.put("startdate", DateTimeUtils.toJsonDate(dataset.getStart()));
-    result.put("enddate", DateTimeUtils.toJsonDate(dataset.getEnd()));
+    result.put("startdate", DateTimeUtils.toIsoDate(dataset.getStart()));
+    result.put("enddate", DateTimeUtils.toIsoDate(dataset.getEnd()));
     result.put("platformCode", instrument.getPlatformCode());
     result.put("nrt", dataset.isNrt());
 

--- a/WebApp/src/uk/ac/exeter/QuinCe/utils/DateTimeUtils.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/utils/DateTimeUtils.java
@@ -51,9 +51,9 @@ public class DateTimeUtils {
   private static SimpleDateFormat dateTimeFormatter = null;
 
   /**
-   * A formatter for generating JSON format dates
+   * A formatter for generating ISO format dates
    */
-  private static java.time.format.DateTimeFormatter jsonFormatter = null;
+  private static java.time.format.DateTimeFormatter isoDateTimeFormatter = null;
 
   /**
    * For formatting LocalDateTime - dates and parsing date time strings
@@ -69,7 +69,7 @@ public class DateTimeUtils {
   static {
     dateTimeFormatter = new SimpleDateFormat(DISPLAY_DATE_TIME_FORMAT);
     dateTimeFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
-    jsonFormatter = java.time.format.DateTimeFormatter.ofPattern("YYYY-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC);
+    isoDateTimeFormatter = java.time.format.DateTimeFormatter.ofPattern("YYYY-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC);
     displayDateTimeFormatter = java.time.format.DateTimeFormatter
         .ofPattern(DISPLAY_DATE_TIME_FORMAT).withZone(ZoneOffset.UTC);
   }
@@ -255,12 +255,12 @@ public class DateTimeUtils {
   }
 
   /**
-   * Generate a JSON-formatted date string for a given date
+   * Generate an ISOformatted date string for a given date
    * @param date The date
-   * @return The JSON string
+   * @return The ISO date string
    */
-  public static String toJsonDate(LocalDateTime date) {
-    return jsonFormatter.format(date);
+  public static String toIsoDate(LocalDateTime date) {
+    return isoDateTimeFormatter.format(date);
   }
 
   /**

--- a/WebApp/src/uk/ac/exeter/QuinCe/web/Instrument/CalibrationBean.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/web/Instrument/CalibrationBean.java
@@ -226,7 +226,7 @@ public abstract class CalibrationBean extends BaseManagedBean {
         JSONObject calibrationJson = new JSONObject();
         calibrationJson.put("type", "box");
         calibrationJson.put("group", groupId);
-        calibrationJson.put("start", DateTimeUtils.toJsonDate(calibration.getDeploymentDate()));
+        calibrationJson.put("start", DateTimeUtils.toIsoDate(calibration.getDeploymentDate()));
         calibrationJson.put("content", calibration.getHumanReadableCoefficients());
         calibrationJson.put("title", calibration.getHumanReadableCoefficients());
 

--- a/WebApp/src/uk/ac/exeter/QuinCe/web/datasets/DataSetsBean.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/web/datasets/DataSetsBean.java
@@ -235,9 +235,9 @@ public class DataSetsBean extends BaseManagedBean {
         entriesJson.append("\"type\":\"range\", \"group\":");
         entriesJson.append(definitionIds.get(file.getFileDefinition().getFileDescription()));
         entriesJson.append(",\"start\":\"");
-        entriesJson.append(DateTimeUtils.toJsonDate(file.getStartDate()));
+        entriesJson.append(DateTimeUtils.toIsoDate(file.getStartDate()));
         entriesJson.append("\",\"end\":\"");
-        entriesJson.append(DateTimeUtils.toJsonDate(file.getEndDate()));
+        entriesJson.append(DateTimeUtils.toIsoDate(file.getEndDate()));
         entriesJson.append("\",\"content\":\"");
         entriesJson.append(file.getFilename());
         entriesJson.append("\",\"title\":\"");
@@ -258,9 +258,9 @@ public class DataSetsBean extends BaseManagedBean {
           entriesJson.append('{');
           entriesJson.append("\"type\":\"background\",");
           entriesJson.append("\"start\":\"");
-          entriesJson.append(DateTimeUtils.toJsonDate(dataSet.getStart()));
+          entriesJson.append(DateTimeUtils.toIsoDate(dataSet.getStart()));
           entriesJson.append("\",\"end\":\"");
-          entriesJson.append(DateTimeUtils.toJsonDate(dataSet.getEnd()));
+          entriesJson.append(DateTimeUtils.toIsoDate(dataSet.getEnd()));
           entriesJson.append("\",\"content\":\"");
           entriesJson.append(dataSet.getName());
           entriesJson.append("\",\"title\":\"");

--- a/WebApp/src/uk/ac/exeter/QuinCe/web/datasets/ExportBean.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/web/datasets/ExportBean.java
@@ -280,7 +280,7 @@ public class ExportBean extends BaseManagedBean {
     StringBuilder output = new StringBuilder();
 
     // The header
-    output.append("Date");
+    output.append("Timestamp");
     output.append(exportOption.getSeparator());
     output.append("Longitude");
     output.append(exportOption.getSeparator());
@@ -320,7 +320,7 @@ public class ExportBean extends BaseManagedBean {
 
       if (exportOption.flagAllowed(recordFlag)) {
 
-        output.append(DateTimeUtils.formatDateTime(sensorRecord.getDate()));
+        output.append(DateTimeUtils.toIsoDate(sensorRecord.getDate()));
         output.append(exportOption.getSeparator());
         output.append(numberFormatter.format(sensorRecord.getLongitude()));
         output.append(exportOption.getSeparator());
@@ -450,8 +450,8 @@ public class ExportBean extends BaseManagedBean {
     for (DataFile file : rawFiles) {
       JSONObject fileJson = new JSONObject();
       fileJson.put("filename", file.getFilename());
-      fileJson.put("startDate", DateTimeUtils.toJsonDate(file.getStartDate()));
-      fileJson.put("endDate", DateTimeUtils.toJsonDate(file.getEndDate()));
+      fileJson.put("startDate", DateTimeUtils.toIsoDate(file.getStartDate()));
+      fileJson.put("endDate", DateTimeUtils.toIsoDate(file.getEndDate()));
       raw.put(fileJson);
     }
     manifest.put("raw", raw);

--- a/configuration/export_config.json
+++ b/configuration/export_config.json
@@ -13,7 +13,7 @@
   	"separator": "comma",
   	"flags": [2],
     "sensors": ["Intake Temperature", "Salinity", "Equilibrator Temperature", "Equilibrator Pressure", "xH2O", "CO2"],
-    "sensors_headings": ["Temp [degC]", "P_sal [psu]", "Temp_in_eq [degC]}", "Press_eq [hPa]", "xH2OEquilSamp [mmol/mol]", "xCO2_dryWater [ppm]"],
+    "sensors_headings": ["Temp [degC]", "P_sal [psu]", "Temp_in_eq [degC]", "Press_eq [hPa]", "xH2OEquilSamp [mmol/mol]", "xCO2_dryWater [ppm]"],
     "equilibrator_pco2_columns": ["pCO2 TE Wet", "pCO2 SST", "fCO2"],
     "equilibrator_pco2_headings": ["pCO2_eqT [ppm]", "pCO2 [ppm]", "fCO2 [uatm]"]
   },

--- a/configuration/export_config.json
+++ b/configuration/export_config.json
@@ -13,9 +13,9 @@
   	"separator": "comma",
   	"flags": [2],
     "sensors": ["Intake Temperature", "Salinity", "Equilibrator Temperature", "Equilibrator Pressure", "xH2O", "CO2"],
-    "sensors_headings": ["Temp", "P_sal", "Temp_in_eq", "Press_eq", "xH2OEquilSamp", "xCO2_dryWater"],
+    "sensors_headings": ["Temp [degC]", "P_sal [psu]", "Temp_in_eq [degC]}", "Press_eq [hPa]", "xH2OEquilSamp [mmol/mol]", "xCO2_dryWater [ppm]"],
     "equilibrator_pco2_columns": ["pCO2 TE Wet", "pCO2 SST", "fCO2"],
-    "equilibrator_pco2_headings": ["pCO2_eqT", "pCO2", "fCO2"]
+    "equilibrator_pco2_headings": ["pCO2_eqT [ppm]", "pCO2 [ppm]", "fCO2 [uatm]"]
   },
   {
     "exportName": "SST+Salinity QC",


### PR DESCRIPTION
* All dates are in ISO format
* Date column renamed to Timestamp
* Column headings have units

Note that the date column changes will apply to all exports. I'm assuming everyone can ingest ISO date formats these days. If we come across any dinosaurs who can't, we'll figure out what to do then.