### PR TITLE
(#1135 #1136) Login page fixes

### DIFF
--- a/WebApp/WebContent/index.xhtml
+++ b/WebApp/WebContent/index.xhtml
@@ -51,10 +51,10 @@
           </h:panelGrid>
           <h:panelGrid columns="2" cellpadding="5" styleClass="buttonPanel">
             <p:commandButton value="Log In" action="#{loginBean.authenticate}"/>
-            <p:commandButton value="Sign Up" action="#{loginBean.signUp}"/>
           </h:panelGrid>
-          <h:panelGrid columns="1" cellpadding="5" styleClass="buttonPanel">
-            <p:commandLink value="Lost Password" action="#{loginBean.startLostPassword}" styleClass="rightText"/>
+          <h:panelGrid columns="2" cellpadding="5" styleClass="buttonPanel">
+            <p:commandLink value="Sign Up" action="#{loginBean.signUp}" immediate="true"/>
+            <p:commandLink value="Lost Password" action="#{loginBean.startLostPassword}" styleClass="rightText" immediate="true"/>
           </h:panelGrid>
         </h:form>
       </div>


### PR DESCRIPTION
Sign Up is now a link instead of a button

Both Sign Up and Lost Password would fail if either the email or password were empty. Now they don't.