### PR TITLE
(nrt_live) Fix creation of 'only' NRT dataset

### DIFF
--- a/WebApp/src/uk/ac/exeter/QuinCe/api/nrt/MakeNrtDataset.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/api/nrt/MakeNrtDataset.java
@@ -119,7 +119,9 @@ public class MakeNrtDataset {
     }
 
     if (createDataset) {
-      LocalDateTime nrtStartDate = null;
+      // Default to 1st Jan 1900. The real dataset date will be adjusted
+      // when the records are extracted
+      LocalDateTime nrtStartDate = LocalDateTime.of(1900, 1, 1, 0, 0, 0);
       if (null != lastDataset) {
         nrtStartDate = lastDataset.getEnd().plusSeconds(1);
       }

--- a/WebApp/src/uk/ac/exeter/QuinCe/jobs/files/ExtractDataSetJob.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/jobs/files/ExtractDataSetJob.java
@@ -106,7 +106,7 @@ public class ExtractDataSetJob extends Job {
       DataSetRawDataRecord record = rawData.getNextRecord();
       while (null != record) {
 
-        if (null != realStartTime && null != record.getDate()) {
+        if (null == realStartTime && null != record.getDate()) {
           realStartTime = record.getDate();
         }
 


### PR DESCRIPTION
Creating an NRT dataset used to fail if there was no existing data set