### PR TITLE
(#955) Fix trailing column detection

### DIFF
--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Instrument/FileDefinition.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Instrument/FileDefinition.java
@@ -445,7 +445,7 @@ public class FileDefinition implements Comparable<FileDefinition> {
       dataLine = dataLine.trim().replaceAll("  *", " ");
     }
 
-    values = Arrays.asList(dataLine.split(separator));
+    values = Arrays.asList(dataLine.split(separator, dataLine.length()));
     return StringUtils.trimList(values);
   }
 


### PR DESCRIPTION
The way that `dataLines.split` was called meant that empty columns got destroyed, which then triggered that row to have the wrong number of columns. Now it's fixed.

You can test by creating an instrument with the attached file, and then uploading it. The file will be accepted and processed, with blank values during data reduction. (The data reduction will have weird values and some of the automatic QC doesn't pick up things that it should, but that's another issue for another time).

(Note that SST, Ambient Pressure (WBPressure) and Salinity are in the right hand columns and are empty sometimes)
[GOS_2019-098-0000dat.txt](https://github.com/BjerknesClimateDataCentre/QuinCe/files/3068692/GOS_2019-098-0000dat.txt)
