### PR TITLE
(master) Hotfix for NonePreprocessor

### DIFF
--- a/NRT/NonePreprocessor.py
+++ b/NRT/NonePreprocessor.py
@@ -4,5 +4,5 @@ class NonePreprocessor(Preprocessor):
   def get_name():
     return "None"
 
-    def preprocess(self, data):
-      return data
+  def preprocess(self, data):
+    return data.getvalue()


### PR DESCRIPTION
The non-acting preprocessor didn't work do to whitespace (screw you, Python) and a BytesIO misunderstanding.