### PR TITLE
(#1194) Do not trim strings when looking for separators

### DIFF
--- a/WebApp/src/uk/ac/exeter/QuinCe/web/Instrument/newInstrument/FileDefinitionBuilder.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/web/Instrument/newInstrument/FileDefinitionBuilder.java
@@ -184,7 +184,7 @@ public class FileDefinitionBuilder extends FileDefinition {
       searchPattern = Pattern.compile(separator);
     }
 
-    Matcher matcher = searchPattern.matcher(searchString.trim());
+    Matcher matcher = searchPattern.matcher(searchString);
 
     int matchCount = 0;
     while (matcher.find()) {


### PR DESCRIPTION
If there's empty columns on the end, we won't get the right number of columns. It's still a problem with space separators because we can't tell how many there's supposed to be (because multiple spaces may or may not mean multiple columns) but we can't do much about that.

-----

Test files attached. `TP_20180518230152.mit` is tab-separated with empty columns at the end. It should detect 31 columns.

To set up an instrument, Use date/time (note the unusual date format) and lat/lon from the TP file, with `SOtemp` and `SOsal` for intake temperature and salinity. `GO.txt` is a standard General Oceanics file - `equ temp`, `equ press` and `CO2 mm/m` should be all you need.

Once the instrument is defined, both files should be uploadable with correct detection. There's no need to go beyond that.

[Anna.zip](https://github.com/BjerknesClimateDataCentre/QuinCe/files/3169219/Anna.zip)
