### PR TITLE
GitHub/1086 Don't display stack trace on login page

### DIFF
--- a/WebApp/src/uk/ac/exeter/QuinCe/web/User/LoginBean.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/web/User/LoginBean.java
@@ -151,6 +151,7 @@ public class LoginBean extends BaseManagedBean {
 
     } catch (Exception e) {
       internalError(e);
+      result = INTERNAL_ERROR_RESULT;
     }
 
     getSession().removeAttribute("SESSION_EXPIRED");


### PR DESCRIPTION
If an error occurs during authentication, the site now redirects to the internal error page.

Close #1086 