### PR TITLE
GitHub/1354 Handle non-numeric values

### DIFF
--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Dataset/DataReduction/DataReductionRecord.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Dataset/DataReduction/DataReductionRecord.java
@@ -8,6 +8,7 @@ import com.google.gson.Gson;
 
 import uk.ac.exeter.QuinCe.data.Dataset.Measurement;
 import uk.ac.exeter.QuinCe.data.Dataset.QC.Flag;
+import uk.ac.exeter.QuinCe.utils.MathUtils;
 import uk.ac.exeter.QuinCe.utils.NoEmptyStringList;
 
 public class DataReductionRecord {
@@ -115,6 +116,6 @@ public class DataReductionRecord {
    */
   public String getCalculationJson() {
     Gson gson = new Gson();
-    return gson.toJson(calculationValues);
+    return gson.toJson(MathUtils.nanToNull(calculationValues));
   }
 }

--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Files/DataFile.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Files/DataFile.java
@@ -746,11 +746,34 @@ public class DataFile {
     return result;
   }
 
+  /**
+   * Get a field value from a line. If the line does not have enough fields,
+   * or the field is the defined missing value, returns {@code null}
+   * @param line The line containing the value
+   * @param field The field to retrieve
+   * @param missingValue The defined missing value
+   * @return The extracted value
+   */
   public String getStringValue(List<String> line, int field, String missingValue) {
-    String result = line.get(field).trim();
-    if (result.equals(missingValue)) {
-      result = null;
+    String result = null;
+
+    if (field < line.size()) {
+      result = line.get(field).trim();
+
+      if (result.equals(missingValue)) {
+        result = null;
+      }
+
+      if (null != result) {
+        try {
+          Double.parseDouble(result);
+        } catch (NumberFormatException e) {
+          System.out.println("NumberFormatException: Invalid value '" + result + "'");
+          result = null;
+        }
+      }
     }
+
     return result;
   }
 

--- a/WebApp/src/uk/ac/exeter/QuinCe/utils/MathUtils.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/utils/MathUtils.java
@@ -1,5 +1,8 @@
 package uk.ac.exeter.QuinCe.utils;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class MathUtils {
 
   public static double round(double number, int decimal) {
@@ -8,4 +11,44 @@ public class MathUtils {
     return rounded / Math.pow(10, decimal);
   }
 
+  public static Map<String, Double> nanToNull(Map<String, Double> map) {
+
+
+    Map<String, Double> out = new HashMap<String, Double>();
+    for (Map.Entry<String, Double> entry : map.entrySet()) {
+      if (null != entry.getValue() &&  Double.isNaN(entry.getValue())) {
+        out.put(entry.getKey(), null);
+      } else {
+        out.put(entry.getKey(), entry.getValue());
+      }
+    }
+
+    return out;
+
+/*
+    System.out.println(map);
+    return map.entrySet().stream()
+      .collect(
+        Collectors.toMap(
+          Map.Entry::getKey,
+          e -> Double.isNaN(e.getValue()) ? null : e.getValue()
+        )
+      );
+*/
+  }
+
+  public static Map<String, Double> nullToNan(Map<String, Double> map) {
+
+
+    Map<String, Double> out = new HashMap<String, Double>();
+    for (Map.Entry<String, Double> entry : map.entrySet()) {
+      if (null == entry.getValue()) {
+        out.put(entry.getKey(), Double.NaN);
+      } else {
+        out.put(entry.getKey(), entry.getValue());
+      }
+    }
+
+    return out;
+  }
 }

--- a/WebApp/src/uk/ac/exeter/QuinCe/web/datasets/data/FieldValue.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/web/datasets/data/FieldValue.java
@@ -53,7 +53,11 @@ public class FieldValue {
     String qcComment, boolean used) {
 
     this.valueId = valueId;
-    this.value = value;
+    if (null == value) {
+      this.value = Double.NaN;
+    } else {
+      this.value = value;
+    }
     this.qcFlag = qcFlag;
     this.needsFlag = needsFlag;
     this.qcComment = qcComment;
@@ -74,7 +78,11 @@ public class FieldValue {
     Flag userQCFlag, String qcComment, boolean used) throws RoutineException {
 
     this.valueId = valueId;
-    this.value = value;
+    if (null == value) {
+      this.value = Double.NaN;
+    } else {
+      this.value = value;
+    }
 
     if (userQCFlag.equals(Flag.NEEDED)) {
       this.qcFlag = autoQC.getOverallFlag();


### PR DESCRIPTION
We ignore these, and log them to the console. We need a better solution in future (see #1338).

`NaN` values in data reduction records are now handled better too.