### PR TITLE
(#1409) Fix Pipfile; Use offset mechanism in requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 **/*.sqlite
 DataPreparation/sqlite/*.csv
 **/__pycache__
+**/Pipfile.lock
 .pydevproject
 **/*.log
 

--- a/external_scripts/NRT/Saildrone_conversion/Pipfile
+++ b/external_scripts/NRT/Saildrone_conversion/Pipfile
@@ -6,12 +6,8 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-json = "*"
 pandas = "*"
-urllib = "*"
 pysftp = "*"
-bytesio = "*"
-io = "*"
 
 [requires]
 python_version = "3.7"

--- a/external_scripts/NRT/Saildrone_conversion/README.md
+++ b/external_scripts/NRT/Saildrone_conversion/README.md
@@ -23,3 +23,4 @@ process is correct. The json files, csv files and the final exported files gets
 stored in directories named by the timestamp when the main script was ran. The
 file names always start with the drone id. For the exported file, the file name
 is followed by the start and end timestamp for the data it contains.
+

--- a/external_scripts/NRT/Saildrone_conversion/config.json
+++ b/external_scripts/NRT/Saildrone_conversion/config.json
@@ -96,7 +96,7 @@
     "FTP": {
         "server": "quince-scripts.bcdc.no",
         "user": "ubuntu",
-        "private_key_file":"C:/users/cla023/PuTTy Keys/camilla.pem",
+        "private_key_file":"/Users/zuj007/.ssh/id_rsa",
         "private_key_pass": "",
         "dir": "FTP_TEST"
     }

--- a/external_scripts/NRT/Saildrone_conversion/saildrone_module/api.py
+++ b/external_scripts/NRT/Saildrone_conversion/saildrone_module/api.py
@@ -11,7 +11,7 @@
 
 #------------------------------------------------------------------------------
 import json
-import urllib
+import urllib.request
 import os
 import pandas as pd
 from datetime import datetime
@@ -81,12 +81,15 @@ def write_json(data_dir, drone_id, dataset, start, end, token):
 	# keep requesting (while loop) until we do not receive any data
 	more_to_request = True
 	data_list_concat = []
+	offset = 0
 	while (more_to_request is True):
 
 		# Define the download request URL
 		get_data_url = 'https://developer-mission.saildrone.com/v1/timeseries/'\
 		+ f'{drone_id}?data_set={dataset}&interval=1&start_date={start}&end_date='\
-		+ f'{end}&order_by=asc&limit=1000&offset=0&token={token}'
+		+ f'{end}&order_by=asc&limit=1000&offset={offset}&token={token}'
+
+		print(get_data_url)
 
 		# Send request
 		data_request = urllib.request.Request(
@@ -102,12 +105,8 @@ def write_json(data_dir, drone_id, dataset, start, end, token):
 			more_to_request = False
 		else:
 			data_list_concat = data_list_concat + data_dict['data']
+			offset = offset + len(data_dict['data'])
 
-			last_dict = data_dict['data'][-1:]
-			last_record = datetime.strptime(last_dict[0]['time_interval'],
-			 "%Y-%m-%dT%H:%M:%S.000Z")
-			start = (last_record +
-				pd.Timedelta("1 minute")).strftime("%Y-%m-%dT%H:%M:%S.000Z")
 
 	# Replace the data section of the last json file received with the
 	# concatenated data list


### PR DESCRIPTION
Previously the back-to-back multiple requests to SailDrone shifted the start date rather than using the offset mechanism provided in the API. The latter is the way they expect us to use it, so we will.