### PR TITLE
(#1624) Allow file search with equal start and end dates

### DIFF
--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Files/DataFileDB.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Files/DataFileDB.java
@@ -887,8 +887,9 @@ public class DataFileDB {
     MissingParam.checkMissing(start, "start");
     MissingParam.checkMissing(end, "end");
 
-    if (end.equals(start) || end.isBefore(start)) {
-      throw new IllegalArgumentException("End date must be after start date");
+    if (end.isBefore(start)) {
+      throw new IllegalArgumentException(
+        "End date must not be before start date");
     }
 
     List<DataFile> files = new ArrayList<DataFile>();


### PR DESCRIPTION
This is used to find files that overlap a given date range, usually for an uploaded file. It's possible that a file can be uploaded with just one record and thus having start and end dates be equal is valid. So we allow these searches.