### PR TITLE
(#1641) Revised NRT dataset creation logic

### DIFF
--- a/WebApp/src/uk/ac/exeter/QuinCe/jobs/files/CreateNrtDataset.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/jobs/files/CreateNrtDataset.java
@@ -81,7 +81,7 @@ public class CreateNrtDataset extends Job {
       // The real dataset date will be adjusted when the records are extracted
       LocalDateTime nrtStartDate = LocalDateTime.of(1900, 1, 1, 0, 0, 0);
       DataSet lastDataset = DataSetDB.getLastDataSet(conn,
-        instrument.getDatabaseId());
+        instrument.getDatabaseId(), false);
       if (null != lastDataset) {
         nrtStartDate = lastDataset.getEnd().plusSeconds(1);
       }

--- a/WebApp/src/uk/ac/exeter/QuinCe/web/Instrument/CalibrationBean.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/web/Instrument/CalibrationBean.java
@@ -171,7 +171,7 @@ public abstract class CalibrationBean extends BaseManagedBean {
 
     if (ok) {
       try {
-        datasets = DataSetDB.getDataSets(getDataSource(), instrumentId);
+        datasets = DataSetDB.getDataSets(getDataSource(), instrumentId, true);
         dbInstance = getDbInstance();
         loadCalibrations();
         affectedDatasets = null;

--- a/WebApp/src/uk/ac/exeter/QuinCe/web/datasets/DataSetsBean.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/web/datasets/DataSetsBean.java
@@ -154,7 +154,7 @@ public class DataSetsBean extends BaseManagedBean {
     RecordNotFoundException, InstrumentException, ResourceException {
     if (null != getCurrentInstrument()) {
       dataSets = DataSetDB.getDataSets(getDataSource(),
-        getCurrentInstrument().getDatabaseId());
+        getCurrentInstrument().getDatabaseId(), true);
       hasFiles = DataFileDB.getFileCount(getDataSource(),
         getCurrentInstrument().getDatabaseId()) > 0;
     } else {


### PR DESCRIPTION
Ignores NRT dataset when looking for last dataset, because sometimes the call is made before the existing NRT dataset is deleted.