### PR TITLE
(#1688) Strip commas and quotes from QC messages

### DIFF
--- a/WebApp/src/uk/ac/exeter/QuinCe/web/datasets/export/ExportBean.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/web/datasets/export/ExportBean.java
@@ -354,8 +354,18 @@ public class ExportBean extends BaseManagedBean {
                 if (null == fieldValue || fieldValue.isGhost()) {
                   output.append("");
                 } else {
-                  output.append(
-                    StringUtils.makeCsvString(fieldValue.getQcComment()));
+
+                  // TODO Temporary fix to strip commas and quotes from
+                  // QC messages, because the destination CSV parse is broken.
+                  String qcMessage = fieldValue.getQcComment();
+                  qcMessage = qcMessage.replaceAll("\"", "").replaceAll(",",
+                    "");
+
+                  output.append(qcMessage);
+
+                  // old version
+                  // output.append(
+                  // StringUtils.makeCsvString(fieldValue.getQcComment()));
                 }
               }
             }


### PR DESCRIPTION
This is to accommodate a bad CSV parser elsewhere. They're going to fix it, at which point this will be reverted.