### PR TITLE
(#1714) Fix handling of combined position column

### DIFF
--- a/WebApp/src/uk/ac/exeter/QuinCe/web/datasets/data/FieldSets.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/web/datasets/data/FieldSets.java
@@ -264,7 +264,8 @@ public class FieldSets extends LinkedHashMap<FieldSet, List<Field>> {
         // Replace lon/lat fields with a single position field ID
         if (field.getId() == FileDefinition.LONGITUDE_COLUMN_ID) {
           headings.add(FieldSets.POSITION_FIELD_ID);
-        } else if (field.getId() != FileDefinition.LATITUDE_COLUMN_ID) {
+        } else {
+          // } else if (field.getId() != FileDefinition.LATITUDE_COLUMN_ID) {
           // Ignore the latitude column
           headings.add(field.getId());
         }

--- a/WebApp/src/uk/ac/exeter/QuinCe/web/datasets/plotPage/ManualQC/ManualQcBean.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/web/datasets/plotPage/ManualQC/ManualQcBean.java
@@ -373,7 +373,7 @@ public class ManualQcBean extends PlotPageBean {
           // We can use the selected QC value if (a) the position QC is not
           // confirmed
           // or (b) the auto QC is worse than the position QC
-          if (position.needsFlag()
+          if (null == position || position.needsFlag()
             || flag.moreSignificantThan(position.getQcFlag())) {
 
             value.setQC(flag, userComment);


### PR DESCRIPTION
In the rectangle selection, the column was off by one because it didn't know the latitude was hidden.