### PR TITLE
1795 Log exceptions in export API

### DIFF
--- a/WebApp/src/uk/ac/exeter/QuinCe/api/export/ExportList.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/api/export/ExportList.java
@@ -97,6 +97,7 @@ public class ExportList {
       }
       result = json.toString();
     } catch (Exception e) {
+      e.printStackTrace();
       throw e;
     } finally {
       DatabaseUtils.closeConnection(conn);


### PR DESCRIPTION
There can still be improvements to error handling, but at least we'll be notified that errors have happened now.