### PR TITLE
(#1978) Requires Python 3 only

### DIFF
--- a/external_scripts/NRT/Pipfile
+++ b/external_scripts/NRT/Pipfile
@@ -16,4 +16,4 @@ numpy = "*"
 [dev-packages]
 
 [requires]
-python_version = "3.9"
+python_version = "3"


### PR DESCRIPTION
Was 3.9, which isn't available on the server.