### PR TITLE
(#2578) Allow duplicate L0 filenames in Carbon Portal

### DIFF
--- a/external_scripts/export/modules/CarbonPortal/Export_CarbonPortal_metadata.py
+++ b/external_scripts/export/modules/CarbonPortal/Export_CarbonPortal_metadata.py
@@ -67,6 +67,9 @@ def build_metadata_package(file,manifest,index,hashsum,
       'start':manifest['manifest']['raw'][index]['startDate'],
       'stop': manifest['manifest']['raw'][index]['endDate']})
     meta['fileName'] = os.path.split(file)[-1]
+    meta['references'] = {
+      "duplicateFilenameAllowed": True
+    }
 
   meta_JSON = json.dumps(meta) # converting from dictionary to json-object
   logging.debug(f'metadata-package: {type(meta_JSON)}\n \


### PR DESCRIPTION
This prevents an error state introduced in the latest Carbon Portal update. Eventually we have to correctly deprecate L0 files when new versions are uploaded.