### PR TITLE
(#2712) Make total CO2 difference more lenient

### DIFF
--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Dataset/QC/DataReduction/D12D13TotalCO2CheckRoutine.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Dataset/QC/DataReduction/D12D13TotalCO2CheckRoutine.java
@@ -67,7 +67,7 @@ public class D12D13TotalCO2CheckRoutine extends DataReductionQCRoutine {
 
           Double difference = totalCO2 - (d12CO2 + d13CO2);
 
-          if (Math.abs(difference) > 0.0001D) {
+          if (Math.abs(difference) > 0.001D) {
             flagSensors(instrument, measurement, record, allSensorValues,
               new RoutineFlag(this, Flag.BAD, "", ""), flaggedItems);
           }


### PR DESCRIPTION
Some processors/OSes have different rounding thresholds that were causing this to be triggered too frequently.