### PR TITLE
(#----) Ignore unused run type

### DIFF
--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Dataset/ProOceanusCO2MeasurementLocator.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Dataset/ProOceanusCO2MeasurementLocator.java
@@ -162,17 +162,20 @@ public class ProOceanusCO2MeasurementLocator extends MeasurementLocator {
          * TSG data).
          */
         if (null != runType) {
-          if (runType.getStringValue().equals(WATER_MODE)
-            && instrument.hasVariable(waterVar)) {
-            measurements.add(new Measurement(dataset.getId(),
-              runType.getNominalTime(), waterRunTypes));
-          } else if (runType.getStringValue().equals(ATM_MODE)
-            && instrument.hasVariable(atmVar)) {
-            measurements.add(new Measurement(dataset.getId(),
-              runType.getNominalTime(), atmRunTypes));
+          if (runType.getStringValue().equals(WATER_MODE)) {
+            if (instrument.hasVariable(waterVar)) {
+              measurements.add(new Measurement(dataset.getId(),
+                runType.getNominalTime(), waterRunTypes));
+            }
+          } else if (runType.getStringValue().equals(ATM_MODE)) {
+            if (instrument.hasVariable(atmVar)) {
+              measurements.add(new Measurement(dataset.getId(),
+                runType.getNominalTime(), atmRunTypes));
+            }
           } else {
             throw new MeasurementLocatorException(
-              "Unrecognised ProOceanus mode '" + runType + "'");
+              "Unrecognised ProOceanus mode '" + runType.getStringValue()
+                + "'");
           }
         }
       }


### PR DESCRIPTION
If the instrument was configured not to use atmospheric measurements, and the "A M" run type was present, it used to throw an error. Now it's just ignored.
