### PR TITLE
(#----) Find CP stations by ID instead of name

### DIFF
--- a/external_scripts/export/modules/CarbonPortal/Export_CarbonPortal_http.py
+++ b/external_scripts/export/modules/CarbonPortal/Export_CarbonPortal_http.py
@@ -136,7 +136,7 @@ prefix cpmeta: <http://meta.icos-cp.eu/ontologies/cpmeta/>
 select ?uri
 from <http://meta.icos-cp.eu/resources/icos/>
 where {{
-    ?uri a cpmeta:OS ; cpmeta:hasName "{name}"^^xsd:string .
+    ?uri a cpmeta:OS ; cpmeta:hasStationId "{name}"^^xsd:string .
 }}
 """
 


### PR DESCRIPTION
The station name in the CP metadata is now the human-friendly name. The coded name has been moved to Station ID.
